### PR TITLE
[GW] feat: implement updating order-state api structure

### DIFF
--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderController.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderController.kt
@@ -26,7 +26,6 @@ class OrderController(
     }
 
     @PatchMapping("/{orderId}")
-    // TODO: authorization for employee
     suspend fun updateOrderState(
             @RequestParam("userId") userId: String,
             @RequestParam("orderState") orderState: String): Mono<Unit> {

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderController.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderController.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.heeheepresso.gateway.order.dto.OrderResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -28,7 +29,7 @@ class OrderController(
     @PatchMapping("/{orderId}")
     suspend fun updateOrderState(
             @RequestParam("userId") userId: String,
-            @RequestParam("orderState") orderState: String): Mono<Unit> {
+            @RequestBody(required = true) orderState: String): Mono<Unit> {
         return orderService.updateOrderState(userId, orderState)
                 .onErrorResume { e ->
                     logger.error("order state updating error: ${e.message}" + e)

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderController.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderController.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.heeheepresso.gateway.order.dto.OrderResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -28,9 +29,10 @@ class OrderController(
 
     @PatchMapping("/{orderId}")
     suspend fun updateOrderState(
+            @PathVariable("orderId") orderId: Long,
             @RequestParam("userId") userId: String,
             @RequestBody(required = true) orderState: String): Mono<Unit> {
-        return orderService.updateOrderState(userId, orderState)
+        return orderService.updateOrderState(orderId, userId, orderState)
                 .onErrorResume { e ->
                     logger.error("order state updating error: ${e.message}" + e)
                     Mono.error(e)

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderController.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderController.kt
@@ -3,6 +3,7 @@ package org.heeheepresso.gateway.order
 import mu.KotlinLogging
 import org.heeheepresso.gateway.order.dto.OrderResponse
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -11,16 +12,28 @@ import reactor.core.publisher.Mono
 @RestController
 @RequestMapping("/orders")
 class OrderController(
-    private val orderService: OrderService
+        private val orderService: OrderService
 ) {
     private val logger = KotlinLogging.logger {}
 
     @GetMapping
-    suspend fun getOrders(@RequestParam("userId") userId : String): Mono<OrderResponse> {
+    suspend fun getOrders(@RequestParam("userId") userId: String): Mono<OrderResponse> {
         return orderService.getOrders(userId)
-            .onErrorResume {  e ->
-                logger.error("menu detail error: ${e.message}" + e)
-                Mono.error(e)
-            }
+                .onErrorResume { e ->
+                    logger.error("menu detail error: ${e.message}" + e)
+                    Mono.error(e)
+                }
+    }
+
+    @PatchMapping("/{orderId}")
+    // TODO: authorization for employee
+    suspend fun updateOrderState(
+            @RequestParam("userId") userId: String,
+            @RequestParam("orderState") orderState: String): Mono<Unit> {
+        return orderService.updateOrderState(userId, orderState)
+                .onErrorResume { e ->
+                    logger.error("order state updating error: ${e.message}" + e)
+                    Mono.error(e)
+                }
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderService.kt
@@ -8,22 +8,46 @@ import org.heeheepresso.gateway.order.dto.OrderResponse
 import org.heeheepresso.gateway.user.UserService
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
+import kotlin.IllegalArgumentException
 
 @Service
 class OrderService(
-    private val userService: UserService,
-    private val orderApiService: OrderApiService,
+        private val userService: UserService,
+        private val orderApiService: OrderApiService,
 ) {
     suspend fun getOrders(userId: String): Mono<OrderResponse> = coroutineScope {
         mono { userService.getUserRole(userId) }
-            .map {  OrderApiRequest(
-               userId = userId,
-               userRole = it,
-            )}
-            .map { orderApiService.getOrders(it) }
-            .map { OrderResponse(
-                userId = it.userId,
-                orders = it.orders,
-            )}
+                .map {
+                    OrderApiRequest(
+                            userId = userId,
+                            userRole = it,
+                    )
+                }
+                .map { orderApiService.getOrders(it) }
+                .map {
+                    OrderResponse(
+                            userId = it.userId,
+                            orders = it.orders,
+                    )
+                }
     }
+
+    suspend fun updateOrderState(userId: String, orderState: String): Mono<Unit> = coroutineScope {
+        mono {
+            userService.getUserRole(userId)
+        }.map {
+            OrderApiRequest(
+                    userId = userId,
+                    userRole = it
+            )
+        }.map {
+            try {
+                val state = OrderState.valueOf(orderState)
+                orderApiService.updateOrderState(it, state)
+            } catch (e: IllegalArgumentException) {
+                throw IllegalArgumentException("Error: Invalid Order State Value")
+            }
+        }
+    }
+
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderService.kt
@@ -43,6 +43,9 @@ class OrderService(
         }.map {
             try {
                 val state = OrderState.valueOf(orderState)
+                if(!OrderState.isAcceptableOrderStateByRole(it.userRole, state))
+                    throw IllegalArgumentException("Error: Invalid operation request")
+
                 orderApiService.updateOrderState(it, state)
             } catch (e: IllegalArgumentException) {
                 throw IllegalArgumentException("Error: Invalid Order State Value")

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderState.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderState.kt
@@ -10,7 +10,7 @@ enum class OrderState {
     CANCELED, // by customer
     REJECTED; // by employee
     companion object{
-        fun isAcceptableOrderStateByRole(userRole: UserRole, orderState: OrderState): Boolean{
+        fun isAbleToChangeByRole(userRole: UserRole, orderState: OrderState): Boolean{
             return when(userRole){
                 UserRole.CUSTOMER -> {
                     when(orderState){

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderState.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderState.kt
@@ -1,9 +1,26 @@
 package org.heeheepresso.gateway.order
 
+import org.heeheepresso.gateway.user.UserRole
+
 enum class OrderState {
     PAID,
     CHECKED,
     WAITING,
     RECEIVED,
-    CANCELED,
+    CANCELED, // by customer
+    REJECTED; // by employee
+    companion object{
+        fun isAcceptableOrderStateByRole(userRole: UserRole, orderState: OrderState): Boolean{
+            return when(userRole){
+                UserRole.CUSTOMER -> {
+                    when(orderState){
+                        CANCELED -> true
+                        else -> false
+                    }
+                }
+                else -> true
+            }
+        }
+    }
+
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderState.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/OrderState.kt
@@ -1,0 +1,9 @@
+package org.heeheepresso.gateway.order
+
+enum class OrderState {
+    PAID,
+    CHECKED,
+    WAITING,
+    RECEIVED,
+    CANCELED,
+}

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/api/OrderApiService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/api/OrderApiService.kt
@@ -1,6 +1,7 @@
 package org.heeheepresso.gateway.order.api
 
 import com.google.common.collect.Lists
+import org.heeheepresso.gateway.order.OrderState
 import org.heeheepresso.gateway.user.UserRole.CUSTOMER
 import org.heeheepresso.gateway.user.UserRole.EMPLOYEE
 
@@ -22,5 +23,9 @@ class OrderApiService {
                 )
             }
         }
+    }
+
+    fun updateOrderState(orderApiRequest: OrderApiRequest, orderState: OrderState){
+        // TODO : implement calling updating order state
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/api/OrderApiService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/api/OrderApiService.kt
@@ -2,6 +2,7 @@ package org.heeheepresso.gateway.order.api
 
 import com.google.common.collect.Lists
 import org.heeheepresso.gateway.order.OrderState
+import org.heeheepresso.gateway.order.dto.OrderCommandApiRequest
 import org.heeheepresso.gateway.user.UserRole.CUSTOMER
 import org.heeheepresso.gateway.user.UserRole.EMPLOYEE
 
@@ -25,7 +26,7 @@ class OrderApiService {
         }
     }
 
-    fun updateOrderState(orderApiRequest: OrderApiRequest, orderState: OrderState){
+    fun updateOrderState(orderCommandApiRequest: OrderCommandApiRequest, orderState: OrderState){
         // TODO : implement calling updating order state
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/order/dto/OrderCommandApiRequest.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/order/dto/OrderCommandApiRequest.kt
@@ -1,0 +1,9 @@
+package org.heeheepresso.gateway.order.dto
+
+import org.heeheepresso.gateway.user.UserRole
+
+data class OrderCommandApiRequest(
+        val orderId: Long,
+        val userId: String,
+        val userRole: UserRole,
+)


### PR DESCRIPTION
## 게이트웨이 레이어
- 주문 상태 변경 API 구조 임의 구현
  - ㄴ 주문 상태를 Enum으로 임의로 정의
  - 이를 기반으로 ROLE에 따른 요청 가능한 OrderState 구분
    - CANCELED(주문 취소) by 구매자
    - 나머지 by 직원 

## 논의할 부분
1. 게이트웨이에서 Global Exception를 할 것인가? (또는 서비스마다 정의할 것인가)
  - 서비스에서 발생한 Exception을 그대로 게이트웨이 던질 것인가 vs. 서비스에서 발생한 Exception을 서비스에서 처리하고 그에 대한 response를 게이트웨이에 전달
2. 요청 데이터 validation을 게이트웨이에서 처리할 것인가 서비스에서 처리할 것인가?
3. Custom Exception을 정의하여 Response를 통일하는 것에 대한 의견
4. 주문 팀에서 정의하겠지만 '주문취소'와 '주문거절'에 대한 상태 분리

(위 부분은 제 지식이 아직 부족하여 의견을 듣고싶어 작성했습니다.)