### PR TITLE
[GW] feat: define user entity

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	// spring boot
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 	// kotlin
 	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
@@ -43,6 +44,9 @@ dependencies {
 	// spring cloud
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-mvc'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
+
+	// database
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/GatewayApplication.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/GatewayApplication.kt
@@ -4,10 +4,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
 @EnableEurekaServer
 @EnableCaching
+@EnableJpaAuditing
 class GatewayApplication
 
 fun main(args: Array<String>) {

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/user/domain/User.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/user/domain/User.kt
@@ -2,13 +2,14 @@ package org.heeheepresso.gateway.user.domain
 
 import jakarta.persistence.*
 import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
 @Entity
+@EntityListeners(AuditingEntityListener::class)
 class User(
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
-        @Column(name = "USER_ID")
         val id: Long,
         @Column(unique = true, nullable = false)
         val phoneNumber: String,

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/user/domain/User.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/user/domain/User.kt
@@ -1,0 +1,23 @@
+package org.heeheepresso.gateway.user.domain
+
+import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import java.time.LocalDateTime
+
+@Entity
+class User(
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "USER_ID")
+        val id: Long,
+        @Column(unique = true, nullable = false)
+        val phoneNumber: String,
+        @Column(length = 15, nullable = false)
+        val username: String,
+        @Enumerated(EnumType.STRING)
+        @Column(nullable = false)
+        val userRole: UserRole,
+        @CreatedDate
+        @Column(updatable = false, nullable = false)
+        val registerDate: LocalDateTime
+)

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/user/domain/UserRole.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/user/domain/UserRole.kt
@@ -1,0 +1,6 @@
+package org.heeheepresso.gateway.user.domain
+
+enum class UserRole {
+    USER,
+    EMPLOYEE
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -12,6 +12,18 @@ eureka:
       defaultZone: http://127.0.0.1:8761/eureka/
 
 spring:
+  datasource:
+    url: jdbc:mysql://127.0.0.1:3306/gateway?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: root
+    password: 0000
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
   application:
     name: gateway
   cloud:


### PR DESCRIPTION
- 게이트웨이와 유저 서비스 통합에 따라 게이트웨이에서 유저 엔티티를 정의하였습니다.
  - 게이트웨이에서 BaseEntity는 재사용 가능성이 많이 없다고 생각해서 굳이 필요없을 것 같다고 판단되었고, 수정이 많이 일어나지 않게끔 하기 위해 생성일자 컬럼만 추가했습니다.
  - 유저 이름에 대한 필드는 원래 계획 상에서는 없었지만 피그마 상에서 존재해서 우선 추가해봤습니다. 
- 데이터베이스 연결을 위한 dependency 추가 (게이트웨이에서는 MySQL을 사용하며, database 이름은 gateway로 사용합니다.)
- datasource 연결에 대한 configuration 추가
