### PR TITLE
[GW] chore: add swagger configuration

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -1,68 +1,71 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
-	id 'org.jetbrains.kotlin.jvm' version '1.9.22'
-	id 'org.jetbrains.kotlin.plugin.spring' version '1.9.22'
+    id 'org.springframework.boot' version '3.2.2'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
+    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.22'
 }
 
 group = 'org.heeheepresso'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springCloudVersion', "2023.0.0")
+    set('springCloudVersion', "2023.0.0")
 }
 
 dependencies {
-	// spring boot
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // spring boot
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-	// kotlin
-	implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
-	implementation 'io.projectreactor.kotlin:reactor-kotlin-extensions'
-	implementation 'org.jetbrains.kotlin:kotlin-reflect'
-	implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor'
+    // kotlin
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
+    implementation 'io.projectreactor.kotlin:reactor-kotlin-extensions'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor'
 
-	// logging
-	implementation 'io.github.microutils:kotlin-logging-jvm:2.0.11'
+    // logging
+    implementation 'io.github.microutils:kotlin-logging-jvm:2.0.11'
 
-	// cache
-	implementation 'org.springframework.boot:spring-boot-starter-cache'
-	implementation 'com.github.ben-manes.caffeine:caffeine'
+    // cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
-	// spring cloud
-	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-mvc'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
+    // spring cloud
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway-mvc'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
 
-	// test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'io.projectreactor:reactor-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.withType(KotlinCompile) {
-	kotlinOptions {
-		freeCompilerArgs += '-Xjsr305=strict'
-		jvmTarget = '17'
-	}
+    kotlinOptions {
+        freeCompilerArgs += '-Xjsr305=strict'
+        jvmTarget = '17'
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/config/SwaggerConfig.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/config/SwaggerConfig.kt
@@ -1,0 +1,24 @@
+package org.heeheepresso.gateway.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openApi(): OpenAPI{
+        return OpenAPI()
+                .components(Components())
+                .info(this.apiInfo())
+        // TODO: 시큐리티 처리 및 공통 에러 응답 처리; https://akku-dev.tistory.com/158
+    }
+
+    private fun apiInfo() = Info()
+            .title("HeeHeePresso API")
+            .description("HeeHeePresso Gateway API Documents")
+            .version("1.0.0")
+}

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/config/SwaggerRedirector.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/config/SwaggerRedirector.kt
@@ -1,0 +1,14 @@
+package org.heeheepresso.gateway.config
+
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.servlet.view.RedirectView
+
+@Controller
+class SwaggerRedirector {
+
+    @RequestMapping("/swagger")
+    fun swagger(): RedirectView{
+        return RedirectView("/swagger-ui/index.html")
+    }
+}


### PR DESCRIPTION
- 프론트에 대한 게이트웨이 API 문서 제공을 용이하게 하기 위해 Swagger 설정을 추가했습니다. (기본 Configuration만 추가했습니다)
  - 게이트웨이에서는 기능이 아니라 화면 별로 API 제공을 하기로 결정했습니다. 
  - 최근 Swagger 설정 방식이 바뀌었나봅니다. dependency가 swagger-ui가 아니라 openapi-ui로 사용하네요.
- path가 너무 길어 /swagger만으로도 리다이렉트하게끔 컨트롤러를 만들었습니다. 