### PR TITLE
ORDER-3 주문 애그리거트 설계 및 구현

### DIFF
--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/application/OrderService.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/application/OrderService.kt
@@ -1,0 +1,18 @@
+package org.heeheepresso.orderapi.order.application
+
+import org.heeheepresso.orderapi.order.domain.repository.OrderRepository
+import org.heeheepresso.orderapi.order.dto.request.OrderCreateRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OrderService(
+    private val orderRepository: OrderRepository
+) {
+
+    @Transactional
+    fun createOrder(request: OrderCreateRequest) {
+        orderRepository.save(request.toEntity())
+    }
+
+}

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/application/OrderService.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/application/OrderService.kt
@@ -1,5 +1,6 @@
 package org.heeheepresso.orderapi.order.application
 
+import org.heeheepresso.orderapi.order.domain.model.Order
 import org.heeheepresso.orderapi.order.domain.repository.OrderRepository
 import org.heeheepresso.orderapi.order.dto.request.OrderCreateRequest
 import org.springframework.stereotype.Service
@@ -11,8 +12,8 @@ class OrderService(
 ) {
 
     @Transactional
-    fun createOrder(request: OrderCreateRequest) {
-        orderRepository.save(request.toEntity())
+    fun createOrder(request: OrderCreateRequest): Order {
+        return orderRepository.save(request.toEntity())
     }
 
 }

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/Buyer.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/Buyer.kt
@@ -1,0 +1,8 @@
+package org.heeheepresso.orderapi.order.domain.model
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class Buyer(
+    val userId: Long
+)

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/Order.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/Order.kt
@@ -33,9 +33,8 @@ class Order(
 
     var packagedYn = packagedYn
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "order_menu", joinColumns = [JoinColumn(name = "order_id")])
-    @OrderColumn(name = "line_idx")
     val orderMenuList: List<OrderMenu> = orderMenuList
 
 }

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/Order.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/Order.kt
@@ -1,0 +1,41 @@
+package org.heeheepresso.orderapi.order.domain.model
+
+import jakarta.persistence.*
+import org.heeheepresso.orderapi.common.BaseEntity
+import java.math.BigDecimal
+
+@Table(name = "orders")
+@Entity
+class Order(
+    userId: Long,
+    storeId: Long,
+    paymentId: Long,
+    amount: BigDecimal,
+    packagedYn: Boolean,
+    orderMenuList: List<OrderMenu>
+) : BaseEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+
+    @Embedded
+    val buyer: Buyer = Buyer(userId)
+
+    @Embedded
+    val store = Store(storeId)
+
+    @Embedded
+    var paymentInfo = PaymentInfo(paymentId, amount)
+
+    @Enumerated(EnumType.STRING)
+    var status = OrderStatus.REQUESTED
+
+    var packagedYn = packagedYn
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "order_menu", joinColumns = [JoinColumn(name = "order_id")])
+    @OrderColumn(name = "line_idx")
+    val orderMenuList: List<OrderMenu> = orderMenuList
+
+}

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/OrderMenu.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/OrderMenu.kt
@@ -1,0 +1,11 @@
+package org.heeheepresso.orderapi.order.domain.model
+
+import jakarta.persistence.Embeddable
+import java.math.BigDecimal
+
+@Embeddable
+data class OrderMenu (
+    val menuId: Long,
+    val price: BigDecimal,
+    val quantity: Int,
+)

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/OrderStatus.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/OrderStatus.kt
@@ -1,4 +1,4 @@
-package org.heeheepresso.orderapi.order
+package org.heeheepresso.orderapi.order.domain.model
 
 enum class OrderStatus(
     val desc: String

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/PaymentInfo.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/PaymentInfo.kt
@@ -1,0 +1,10 @@
+package org.heeheepresso.orderapi.order.domain.model
+
+import jakarta.persistence.Embeddable
+import java.math.BigDecimal
+
+@Embeddable
+data class PaymentInfo(
+    val paymentId: Long,
+    val amount: BigDecimal
+)

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/Store.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/model/Store.kt
@@ -1,0 +1,8 @@
+package org.heeheepresso.orderapi.order.domain.model
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class Store(
+    val storeId: Long
+)

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/repository/OrderRepository.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/repository/OrderRepository.kt
@@ -1,7 +1,16 @@
 package org.heeheepresso.orderapi.order.domain.repository
 
 import org.heeheepresso.orderapi.order.domain.model.Order
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
 
 interface OrderRepository : JpaRepository<Order, Long> {
+
+    @EntityGraph(attributePaths = ["orderMenuList"])
+    override fun findById(id: Long): Optional<Order>
+
+    @EntityGraph(attributePaths = ["orderMenuList"])
+    override fun findAll(): MutableList<Order>
+
 }

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/repository/OrderRepository.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/domain/repository/OrderRepository.kt
@@ -1,0 +1,7 @@
+package org.heeheepresso.orderapi.order.domain.repository
+
+import org.heeheepresso.orderapi.order.domain.model.Order
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface OrderRepository : JpaRepository<Order, Long> {
+}

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/dto/request/OrderCreateRequest.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/dto/request/OrderCreateRequest.kt
@@ -1,0 +1,25 @@
+package org.heeheepresso.orderapi.order.dto.request
+
+import org.heeheepresso.orderapi.order.domain.model.Order
+import java.math.BigDecimal
+
+data class OrderCreateRequest(
+    val orderId: Long,
+    val userId: Long,
+    val amount: BigDecimal,
+    val packagedYn: Boolean,
+    val storedId: Long,
+    val paymentId: Long,
+    val orderMenuList: List<OrderMenuCreateRequest>,
+) {
+    fun toEntity(): Order {
+        return Order(
+            userId = userId,
+            storeId = storedId,
+            paymentId = paymentId,
+            amount = amount,
+            packagedYn = packagedYn,
+            orderMenuList = orderMenuList.map(OrderMenuCreateRequest::toOrderMenu)
+        )
+    }
+}

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/dto/request/OrderCreateRequest.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/dto/request/OrderCreateRequest.kt
@@ -4,7 +4,6 @@ import org.heeheepresso.orderapi.order.domain.model.Order
 import java.math.BigDecimal
 
 data class OrderCreateRequest(
-    val orderId: Long,
     val userId: Long,
     val amount: BigDecimal,
     val packagedYn: Boolean,

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/dto/request/OrderMenuCreateRequest.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/order/dto/request/OrderMenuCreateRequest.kt
@@ -1,0 +1,18 @@
+package org.heeheepresso.orderapi.order.dto.request
+
+import org.heeheepresso.orderapi.order.domain.model.OrderMenu
+import java.math.BigDecimal
+
+data class OrderMenuCreateRequest(
+    val menuId: Long,
+    val price: BigDecimal,
+    val quantity: Int,
+) {
+    fun toOrderMenu(): OrderMenu {
+        return OrderMenu(
+            menuId = menuId,
+            price = price,
+            quantity = quantity,
+        )
+    }
+}

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/orderHistory/OrderHistory.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/orderHistory/OrderHistory.kt
@@ -2,7 +2,7 @@ package org.heeheepresso.orderapi.orderHistory
 
 import jakarta.persistence.*
 import org.heeheepresso.orderapi.common.BaseEntity
-import org.heeheepresso.orderapi.order.OrderStatus
+import org.heeheepresso.orderapi.order.domain.model.OrderStatus
 import org.heeheepresso.orderapi.orderHistory.dto.request.OrderHistoryCreateRequest
 import org.heeheepresso.orderapi.orderHistory.menu.OrderMenuHistory
 import org.heeheepresso.orderapi.orderHistory.menu.dto.request.OrderMenuHistoryCreateRequest

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/orderHistory/dto/request/OrderHistoryCreateRequest.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/orderHistory/dto/request/OrderHistoryCreateRequest.kt
@@ -1,6 +1,6 @@
 package org.heeheepresso.orderapi.orderHistory.dto.request
 
-import org.heeheepresso.orderapi.order.OrderStatus
+import org.heeheepresso.orderapi.order.domain.model.OrderStatus
 import org.heeheepresso.orderapi.orderHistory.menu.dto.request.OrderMenuHistoryCreateRequest
 import java.math.BigDecimal
 

--- a/order-api/src/main/kotlin/org/heeheepresso/orderapi/orderHistory/dto/response/OrderHistoryCreateResponse.kt
+++ b/order-api/src/main/kotlin/org/heeheepresso/orderapi/orderHistory/dto/response/OrderHistoryCreateResponse.kt
@@ -1,6 +1,6 @@
 package org.heeheepresso.orderapi.orderHistory.dto.response
 
-import org.heeheepresso.orderapi.order.OrderStatus
+import org.heeheepresso.orderapi.order.domain.model.OrderStatus
 import org.heeheepresso.orderapi.orderHistory.menu.dto.OrderMenuHistoryDto
 import java.math.BigDecimal
 import java.time.LocalDateTime

--- a/order-api/src/test/kotlin/org/heeheepresso/orderapi/order/application/OrderServiceIntegrationTest.kt
+++ b/order-api/src/test/kotlin/org/heeheepresso/orderapi/order/application/OrderServiceIntegrationTest.kt
@@ -1,0 +1,55 @@
+package org.heeheepresso.orderapi.order.application
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.heeheepresso.orderapi.order.domain.model.OrderStatus
+import org.heeheepresso.orderapi.order.dto.request.OrderCreateRequest
+import org.heeheepresso.orderapi.order.dto.request.OrderMenuCreateRequest
+import org.springframework.boot.test.context.SpringBootTest
+import java.math.BigDecimal
+
+@SpringBootTest
+class OrderServiceIntegrationTest(
+    val orderService: OrderService,
+) : DescribeSpec({
+
+    describe("OrderService 클래스의") {
+        val request = request()
+        context("createOrder 메소드를 실행하면") {
+            val result = orderService.createOrder(request)
+            it("OrderCreateRequest에 담긴 값으로 Order를 저장 후 반환한다") {
+                result.id shouldNotBe null
+                result.buyer.userId shouldBe request.userId
+                result.store.storeId shouldBe request.storedId
+                result.paymentInfo.paymentId shouldBe request.paymentId
+                result.orderMenuList shouldHaveSize request.orderMenuList.size
+                result.packagedYn shouldBe request.packagedYn
+            }
+
+            it("OrderStatus는 REQUESTED(요청) 상태이다") {
+                result.status shouldBe OrderStatus.REQUESTED
+            }
+        }
+
+    }
+
+})
+
+fun request(): OrderCreateRequest {
+    return OrderCreateRequest(
+        1,
+        BigDecimal("2000"),
+        true,
+        1,
+        1,
+        listOf(
+            OrderMenuCreateRequest(1, BigDecimal("1000"), 1),
+            OrderMenuCreateRequest(2, BigDecimal("1000"), 1),
+        )
+    )
+}
+
+
+

--- a/order-api/src/test/kotlin/org/heeheepresso/orderapi/orderHistory/OrderHistoryServiceTest.kt
+++ b/order-api/src/test/kotlin/org/heeheepresso/orderapi/orderHistory/OrderHistoryServiceTest.kt
@@ -3,7 +3,7 @@ package org.heeheepresso.orderapi.orderHistory
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.date.shouldBeAfter
 import io.kotest.matchers.shouldBe
-import org.heeheepresso.orderapi.order.OrderStatus
+import org.heeheepresso.orderapi.order.domain.model.OrderStatus
 import org.heeheepresso.orderapi.orderHistory.dto.request.OrderHistoryCreateRequest
 import org.heeheepresso.orderapi.orderHistory.menu.dto.request.OrderMenuHistoryCreateRequest
 import org.springframework.beans.factory.annotation.Autowired


### PR DESCRIPTION
#14

### 변경 사항
1. 네이밍 변경
    - 테이블 명 'order' -> 'orders'로 변경 (MySQL에 order 예약어 존재)
    - Order의 'price' -> 'amount' 로 변경
        - 결제금액이라는 의미를 명시
        - OrderMenu의 price와의 중복 제거
2. OrderMenu를 Child Entity가 아닌 VO로 설계 
    - 각각의 OrderMenu를 구분(식별)해야 하는 경우는 VO가 아닌 Child Entity를 사용
    - 이후 장바구니 도메인에서 메뉴 처리 로직 확인 후 수정할 가능성 존재
3. OrderService의 주문 생성(createOrder) 메소드 추가 및 간단한 테스트 작성
    - 세부적인 로직은 추가 개발 예정

### 추가 논의사항
- Test 패턴을 'given - when - then' 에서 'Describe - Context - It (DCI)' 패턴으로 변경하는 것을 제안드립니다. 주문팀 회의에서 자세히 논의하면 좋을 것 같습니다.
- 패키지 구조도 회의 후 통일하면 좋을 것 같습니다.