### PR TITLE
[GW] feat: implement api for menu page per category 

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -24,9 +24,9 @@ ext {
 
 dependencies {
     // spring boot
-	  implementation 'org.springframework.boot:spring-boot-starter-security'
-	  implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // kotlin
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
@@ -48,13 +48,19 @@ dependencies {
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
-	  // database
-	  runtimeOnly 'com.mysql:mysql-connector-j'
+    // database
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	  // test
-	  testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	  testImplementation 'io.projectreactor:reactor-test'
-	  testImplementation 'org.springframework.security:spring-security-test'
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // kotest
+    testImplementation("io.kotest:kotest-runner-junit5:5.4.2")
+    testImplementation("io.kotest:kotest-assertions-core:5.4.2")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
+
 }
 
 dependencyManagement {

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/MenuCategory.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/MenuCategory.kt
@@ -1,0 +1,10 @@
+package org.heeheepresso.gateway.menu.category
+
+enum class MenuCategory {
+    SET_MENU,
+    COFFEE,
+    DECAFFINE_COFFEE,
+    BANACCINO_AND_SMOOTHIE,
+    TEA_AND_ADE,
+    BREAD_AND_DESSERT
+}

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/MenuCategoryController.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/MenuCategoryController.kt
@@ -1,8 +1,10 @@
 package org.heeheepresso.gateway.menu.category
 
 import mu.KotlinLogging
+import org.heeheepresso.gateway.menu.category.dto.RecommendedCarousel
 import org.heeheepresso.gateway.menu.category.dto.RecommendedPageResponse
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -10,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/menu")
 class MenuCategoryController(
-    private val menuCategoryService: MenuCategoryService
+        private val menuCategoryService: MenuCategoryService
 ) {
 
     private val logger = KotlinLogging.logger {}
@@ -18,5 +20,12 @@ class MenuCategoryController(
     @GetMapping("/recommendation")
     suspend fun getRecommendedPage(@RequestParam("userId") userId: Long): RecommendedPageResponse {
         return menuCategoryService.getRecommendedPage(userId)
+    }
+
+    @GetMapping("/{category}")
+    suspend fun getPageByCategory(
+            @RequestParam("userId") userId: Long,
+            @PathVariable("category") category: String): RecommendedCarousel {
+        return menuCategoryService.getPageByCategory(userId, category)
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/MenuCategoryService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/MenuCategoryService.kt
@@ -56,7 +56,7 @@ class MenuCategoryService(
             val storeId = async { userService.getStore(userId) } // TODO: redis로부터 매장 정보 가져오기
             // 추천 서비스로부터 주어진 카테고리에 대한 추천 목록 조회
             val result = recommendationService
-                    .getRecommendedMenuByCategory(Context(userId, storeId.await()), menuCategory)
+                    .getMenuByCategory(Context(userId, storeId.await()), menuCategory)
 
             // 상세 메뉴 서비스로부터 고유 메뉴마다의 상세 메뉴 데이터 조회
             val menuDetailMap = async {

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/domain/Menu.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/domain/Menu.kt
@@ -1,8 +1,11 @@
 package org.heeheepresso.gateway.menu.domain
 
+import org.heeheepresso.gateway.menu.category.MenuCategory
+
 data class Menu(
-    val imagePath: String,
-    val title: String,
-    val subTitle: String,
-    val price: Long,
+        val menuCategory: MenuCategory,
+        val imagePath: String,
+        val title: String,
+        val subTitle: String,
+        val price: Long,
 )

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/domain/MenuDetail.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/domain/MenuDetail.kt
@@ -1,11 +1,14 @@
 package org.heeheepresso.gateway.menu.domain
 
+import org.heeheepresso.gateway.menu.category.MenuCategory
+
 data class MenuDetail(
-    val menuId: Long,
-    val imagePath: String,
-    val title: String,
-    val subTitle: String,
-    val price: Long,
+        val menuId: Long,
+        val category: MenuCategory,
+        val imagePath: String,
+        val title: String,
+        val subTitle: String,
+        val price: Long,
 ) {
-    constructor(): this(0, "", "", "", 0)
+    constructor() : this(0, MenuCategory.COFFEE, "", "", "", 0)
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/menuDetail/MenuDetailService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/menuDetail/MenuDetailService.kt
@@ -1,6 +1,7 @@
 package org.heeheepresso.gateway.menu.menuDetail
 
 import com.google.common.collect.ImmutableList
+import org.heeheepresso.gateway.menu.category.MenuCategory
 import org.heeheepresso.gateway.menu.domain.MenuDetail
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
@@ -11,11 +12,19 @@ class MenuDetailService {
     @Cacheable("menuDetail")
     suspend fun getMenuDetails(menuIds: List<Long>): List<MenuDetail> {
         return ImmutableList.of(MenuDetail(
-            menuId = 1L,
-            imagePath = "/sample.png",
-            title = "신승건",
-            subTitle = "ssg",
-            price = 1000,
-        ))
+                menuId = 1L,
+                category = MenuCategory.TEA_AND_ADE,
+                imagePath = "/sample.png",
+                title = "신승건",
+                subTitle = "ssg",
+                price = 1000,
+        ), MenuDetail(
+                menuId = 2L,
+                category = MenuCategory.COFFEE,
+                imagePath = "/sample2.png",
+                title = "김희재",
+                subTitle = "khj",
+                price = 2000)
+        )
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationHandler.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationHandler.kt
@@ -4,4 +4,5 @@ enum class RecommendationHandler {
     NEWLY_RELEASED,
     HIGHLY_RECOMMENDED,
     BREAD,
+    MENU_CATEGORY // 카테고리에 따른 메뉴 목록 조회에 대한 핸들러
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationResult.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationResult.kt
@@ -4,16 +4,19 @@ import org.heeheepresso.gateway.menu.domain.Menu
 import org.heeheepresso.gateway.menu.domain.MenuDetail
 
 data class RecommendationResult(
-    val recommendedMenus: List<RecommendedMenu>,
-    val handler: String,
+        val recommendedMenus: List<RecommendedMenu>,
+        val handler: String,
 ) {
     fun getMenus(menuDetails: Map<Long, MenuDetail>): List<Menu> {
         return this.recommendedMenus
-            .map{ menu -> menuDetails.getOrDefault(menu.menuId, MenuDetail()) }
-            .map{ menuDetail -> Menu(
-                imagePath = menuDetail.imagePath,
-                title = menuDetail.title,
-                subTitle = menuDetail.subTitle,
-                price = menuDetail.price) }
+                .map { menu -> menuDetails.getOrDefault(menu.menuId, MenuDetail()) }
+                .map { menuDetail ->
+                    Menu(
+                            menuCategory = menuDetail.category,
+                            imagePath = menuDetail.imagePath,
+                            title = menuDetail.title,
+                            subTitle = menuDetail.subTitle,
+                            price = menuDetail.price)
+                }
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationService.kt
@@ -3,10 +3,8 @@ package org.heeheepresso.gateway.recommendation
 import com.google.common.collect.ImmutableList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import org.glassfish.jersey.internal.guava.Lists
 import org.heeheepresso.gateway.common.Context
 import org.heeheepresso.gateway.menu.category.MenuCategory
-import org.heeheepresso.gateway.menu.domain.Menu
 import org.springframework.stereotype.Service
 
 @Service
@@ -42,7 +40,7 @@ class RecommendationService {
                 handler = request.handler)
     }
 
-    suspend fun getRecommendedMenuByCategory(context: Context, menuCategory: MenuCategory): RecommendationResult {
+    suspend fun getMenuByCategory(context: Context, menuCategory: MenuCategory): RecommendationResult {
         return coroutineScope {
             async {
                 getRecommendedMenu(RecommendedRequest(

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationService.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.glassfish.jersey.internal.guava.Lists
 import org.heeheepresso.gateway.common.Context
+import org.heeheepresso.gateway.menu.category.MenuCategory
 import org.heeheepresso.gateway.menu.domain.Menu
 import org.springframework.stereotype.Service
 
@@ -16,16 +17,17 @@ class RecommendationService {
     }
 
     suspend fun getRecommendedMenus(
-        context: Context, handlers: ImmutableList<RecommendationHandler>): RecommendationResultSet {
+            context: Context, handlers: ImmutableList<RecommendationHandler>): RecommendationResultSet {
         val resultSet: ArrayList<RecommendationResult> = ArrayList()
         coroutineScope {
             handlers.map {
                 val request = RecommendedRequest(
-                    handler = it.name,
-                    userId = context.userId,
-                    storeId = context.storeId,
-                    pageSize = CAROUSEL_PAGE_SIZE,
-                    offset = 0,)
+                        handler = it.name,
+                        userId = context.userId,
+                        storeId = context.storeId,
+                        pageSize = CAROUSEL_PAGE_SIZE,
+                        offset = 0,
+                )
                 async { getRecommendedMenu(request) }
             }.forEach {
                 resultSet.add(it.await())
@@ -36,7 +38,21 @@ class RecommendationService {
 
     private suspend fun getRecommendedMenu(request: RecommendedRequest): RecommendationResult {
         return RecommendationResult(
-            recommendedMenus = ImmutableList.of(RecommendedMenu(1)),
-            handler = request.handler)
+                recommendedMenus = ImmutableList.of(RecommendedMenu(1)),
+                handler = request.handler)
+    }
+
+    suspend fun getRecommendedMenuByCategory(context: Context, menuCategory: MenuCategory): RecommendationResult {
+        return coroutineScope {
+            async {
+                getRecommendedMenu(RecommendedRequest(
+                        handler = menuCategory.name,
+                        userId = context.userId,
+                        storeId = context.storeId,
+                        pageSize = CAROUSEL_PAGE_SIZE,
+                        offset = 0,
+                ))
+            }.await()
+        }
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationService.kt
@@ -21,6 +21,7 @@ class RecommendationService {
             handlers.map {
                 val request = RecommendedRequest(
                         handler = it.name,
+                        menuCategory = null, // 정해진 카테고리가 없으므로 null 처리
                         userId = context.userId,
                         storeId = context.storeId,
                         pageSize = CAROUSEL_PAGE_SIZE,
@@ -44,7 +45,8 @@ class RecommendationService {
         return coroutineScope {
             async {
                 getRecommendedMenu(RecommendedRequest(
-                        handler = menuCategory.name,
+                        handler = RecommendationHandler.MENU_CATEGORY.name, // 카테고리 메뉴에 대한 요청
+                        menuCategory = menuCategory,
                         userId = context.userId,
                         storeId = context.storeId,
                         pageSize = CAROUSEL_PAGE_SIZE,

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendedRequest.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendedRequest.kt
@@ -1,7 +1,10 @@
 package org.heeheepresso.gateway.recommendation
 
+import org.heeheepresso.gateway.menu.category.MenuCategory
+
 data class RecommendedRequest(
     val handler: String,
+    val menuCategory: MenuCategory?,
     val userId: Long,
     val storeId: Long,
     val pageSize: Int,

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
   datasource:
     url: jdbc:mysql://127.0.0.1:3306/gateway?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
-    password: 0000
+    password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:

--- a/gateway/src/test/kotlin/org/heeheepresso/gateway/menu/category/MenuCategoryServiceTest.kt
+++ b/gateway/src/test/kotlin/org/heeheepresso/gateway/menu/category/MenuCategoryServiceTest.kt
@@ -1,0 +1,25 @@
+package org.heeheepresso.gateway.menu.category
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class MenuCategoryServiceTest @Autowired constructor(
+        private val menuCategoryService: MenuCategoryService
+) : BehaviorSpec({
+    Given("존재하는 메뉴에 대해") {
+        val testCategory = "TEA_AND_ADE"
+        val userId = 1L
+        When("특정 카테고리로 메뉴 목록을 조회하면") {
+            val result = menuCategoryService.getPageByCategory(userId, testCategory)
+            Then("카테고리 별 추천 메뉴 목록을 반환한다.") {
+                result.menus.size shouldBe 1
+                result.handler shouldBe testCategory
+                result.menus.stream().map { it.title }.toList() shouldContainAll listOf("신승건")
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Related Issue
close #17 

## Changes
<img width="242" alt="스크린샷 2024-03-09 오전 9 23 47" src="https://github.com/HeeHeePresso/Backend/assets/54919474/cdd5dfa4-4e9d-4913-945c-2a2dd07e00b4">

- 메뉴 카테고리 정의 (피그마에 작성된 내용을 바탕으로 정의함. 추후 메뉴 팀의 설계에 따라 수정 가능)
- 상세 메뉴 데이터 클래스에 '메뉴 카테고리' 필드 추가 (MenuDetail.kt)
- 카테고리 별 메뉴 목록에도 "추천"의 영역을 포함하였습니다. (각 메뉴의 우선순위)
  - RecommendedRequest 파일 내의 'handler' 필드가 String 타입으로 정의되어서 재사용할 수 있을 것 같다고 판단해서, 단순 추천 메뉴 목록이 아닌 카테고리 별 메뉴 목록에서도 'handler' 필드에 카테고리 값을 할당하여 해당 카테고리로 쿼리를 날릴 수 있게끔 했습니다. 
  - MenuCategoryService에서 추천 서비스로부터 카테고리에 따른 추천 메뉴 목록을 받고, 상세 메뉴 서비스로부터 받은 메뉴들의 PK로 매핑하여 조회하게끔 하는 구조로 만들었습니다. (희재님이 이전 PR에서 작성해주신 구조를 동일하게 사용했습니다.)
  - 그리고 최종 응답 데이터는 일반 추천 메뉴 목록과는 다르게 카테고리 '단 하나'의 대한 결과이므로 이 부분도 마찬가지로 RecommendedCarousel 클래스를 재사용할 수 있을 것 같다고 판단하여 사용하였습니다.
- 해당 기능을 kotest(BDD 패턴)를 사용해서 매우매우 간단하게 테스트를 해보았습니다.
- datasource(MySQL)의 비밀번호를 1234로 수정했습니다. 기존에는 0000이였는데 계속해서 Access Denied가 발생하여 찾아본 결과 비밀번호 정책에 맞지않다고 합니다. (처음 보는 현상..)