### PR TITLE
[Menu] 메뉴 등록 및 조회 기능 추가 #27

### DIFF
--- a/menu/build.gradle
+++ b/menu/build.gradle
@@ -26,6 +26,11 @@ dependencies {
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// kotest
+	testImplementation("io.kotest:kotest-runner-junit5:5.4.2")
+	testImplementation("io.kotest:kotest-assertions-core:5.4.2")
+	testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
 }
 
 tasks.withType(KotlinCompile) {

--- a/menu/src/main/kotlin/org/heeheepresso/menu/common/BaseEntity.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/common/BaseEntity.kt
@@ -1,0 +1,36 @@
+package org.heeheepresso.menu.common
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseEntity {
+
+    @Column(name = "created_by", nullable = false, updatable = false)
+    @CreatedBy
+    var createdBy: String = "system"
+        protected set
+
+    @CreatedDate
+    @Column(name = "created_date", nullable = false, updatable = false)
+    var createdDate: LocalDateTime = LocalDateTime.MIN
+        protected set
+
+    @Column(name = "modified_by", nullable = false)
+    @LastModifiedBy
+    var modifiedBy: String = "system"
+        protected set
+
+    @LastModifiedDate
+    @Column(name = "modified_date", nullable = false)
+    var modifiedDate: LocalDateTime = LocalDateTime.MIN
+        protected set
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/Category.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/Category.kt
@@ -1,0 +1,12 @@
+package org.heeheepresso.menu.domain.menu.model
+
+enum class Category (val desc: String) {
+    COFFEE("COFFEE"),
+    DECAFFEINE_COFFEE("DECAFFEINE_COFFEE"),
+    MILK_TEA_AND_LATTE("MILK_TEA_&_LATTE"),
+    JUICE_AND_DRINK("JUICE_&_DRINK"),
+    TEA_AMD_ADE("TEA_&_ADE"),
+    BREAD("BREAD"),
+    DESSERT("DESSERT"),
+    MD("MD"),
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/FlagType.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/FlagType.kt
@@ -1,0 +1,7 @@
+package org.heeheepresso.menu.domain.menu.model
+
+enum class FlagType {
+    NEW,
+    BEST,
+    SALE,
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/Menu.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/Menu.kt
@@ -1,0 +1,49 @@
+package org.heeheepresso.menu.domain.menu.model
+
+import jakarta.persistence.*
+import org.heeheepresso.menu.common.BaseEntity
+import org.heeheepresso.menu.interfaces.dto.ModifyMenuRequest
+
+@Entity
+class Menu (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val menuId: Long? = null,
+
+    var title: String,
+
+    var subTitle: String,
+
+    var description: String,
+
+    @Enumerated(value = EnumType.STRING)
+    var category: Category,
+
+    @Enumerated(value = EnumType.STRING)
+    var flagType: FlagType? = null,
+
+    @Enumerated(value = EnumType.STRING)
+    var status: MenuStatus,
+
+    @Embedded
+    var menuItemDetail: MenuItemDetail,
+
+    @Embedded
+    var menuItemPrice: MenuItemPrice,
+
+) : BaseEntity(){
+    fun modifyStatus(status: MenuStatus){
+        this.status = status
+    }
+
+    fun modifyMenu(request: ModifyMenuRequest){
+        this.title = request.title
+        this.subTitle = request.subTitle
+        this.description = request.description
+        this.category = request.category
+        this.flagType = request.flagType
+        this.status = request.status
+        this.menuItemDetail = request.menuItemDetail
+        this.menuItemPrice = request.menuItemPrice
+    }
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/MenuItemDetail.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/MenuItemDetail.kt
@@ -1,0 +1,11 @@
+package org.heeheepresso.menu.domain.menu.model
+
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class MenuItemDetail(
+    var temperature: Temperature,
+    var thumbnailUrl: String,
+
+) {
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/MenuItemPrice.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/MenuItemPrice.kt
@@ -1,0 +1,12 @@
+package org.heeheepresso.menu.domain.menu.model
+
+import jakarta.persistence.Embeddable
+import java.math.BigDecimal
+
+@Embeddable
+data class MenuItemPrice(
+    var storePrice: BigDecimal,
+    var salePrice : BigDecimal,
+    var takeOutPrice: BigDecimal,
+) {
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/MenuStatus.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/MenuStatus.kt
@@ -1,0 +1,8 @@
+package org.heeheepresso.menu.domain.menu.model
+
+enum class MenuStatus (val desc: String){
+    SELLING("판매중"),
+    SOLD_OUT("판매마감"),
+    CLOSED("매장마감"),
+    HIDE("메뉴숨김"),
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/Temperature.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/model/Temperature.kt
@@ -1,0 +1,6 @@
+package org.heeheepresso.menu.domain.menu.model
+
+enum class Temperature {
+    HOT,
+    ICE
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/repository/MenuRepository.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/repository/MenuRepository.kt
@@ -1,0 +1,7 @@
+package org.heeheepresso.menu.domain.menu.repository
+
+import org.heeheepresso.menu.domain.menu.model.Menu
+import org.springframework.data.repository.CrudRepository
+
+interface MenuRepository : CrudRepository<Menu, Long> {
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/service/MenuService.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/domain/menu/service/MenuService.kt
@@ -1,0 +1,32 @@
+package org.heeheepresso.menu.domain.menu.service
+
+import org.heeheepresso.menu.domain.menu.model.Menu
+import org.heeheepresso.menu.domain.menu.repository.MenuRepository
+import org.heeheepresso.menu.interfaces.dto.ModifyMenuRequest
+import org.heeheepresso.menu.interfaces.dto.ModifyStatusRequest
+import org.springframework.stereotype.Service
+
+@Service
+class MenuService (
+    val menuRepository: MenuRepository
+        ){
+
+    fun save(input: Menu): Menu{
+        return menuRepository.save(input)
+    }
+
+    fun findById(id: Long): Menu {
+        return menuRepository.findById(id).orElseThrow()
+    }
+
+    fun findAll(): Iterable<Menu> {
+        return menuRepository.findAll()
+    }
+
+    fun modifyStatus(id: Long, request: ModifyStatusRequest): Menu{
+        val menu: Menu = menuRepository.findById(id).orElseThrow()
+        menu.modifyStatus(request.status)
+        return menu
+    }
+
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/interfaces/api/MenuController.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/interfaces/api/MenuController.kt
@@ -1,0 +1,38 @@
+package org.heeheepresso.menu.interfaces.api
+
+import org.heeheepresso.menu.domain.menu.model.Menu
+import org.heeheepresso.menu.domain.menu.service.MenuService
+import org.heeheepresso.menu.interfaces.dto.ModifyMenuRequest
+import org.heeheepresso.menu.interfaces.dto.ModifyStatusRequest
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MenuController (
+    val menuService: MenuService
+        ){
+
+    @GetMapping("/menus")
+    fun getAllMenus(): Iterable<Menu> {
+        return menuService.findAll()
+    }
+
+    @GetMapping("/menus/{menuId}")
+    fun getMenuById(@PathVariable("menuId") menuId: Long): Menu{
+        return menuService.findById(menuId)
+    }
+
+    @PostMapping("/menus")
+    fun createMenu(@RequestBody menu: Menu){
+        menuService.save(menu)
+    }
+
+    @PutMapping("/menus/{menuId}/status")
+    fun changeMenuStatus(@PathVariable("menuId") menuId: Long, @RequestBody modifyStatusRequest: ModifyStatusRequest){
+        menuService.modifyStatus(menuId, modifyStatusRequest)
+    }
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/interfaces/dto/ModifyMenuRequest.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/interfaces/dto/ModifyMenuRequest.kt
@@ -1,0 +1,25 @@
+package org.heeheepresso.menu.interfaces.dto
+
+import jakarta.persistence.Embedded
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import org.heeheepresso.menu.domain.menu.model.*
+
+data class ModifyMenuRequest (
+    var title: String,
+
+    var subTitle: String,
+
+    var description: String,
+
+    var category: Category,
+
+    var flagType: FlagType,
+
+    var status: MenuStatus,
+
+    var menuItemDetail: MenuItemDetail,
+
+    var menuItemPrice: MenuItemPrice,
+        ){
+}

--- a/menu/src/main/kotlin/org/heeheepresso/menu/interfaces/dto/ModifyStatusRequest.kt
+++ b/menu/src/main/kotlin/org/heeheepresso/menu/interfaces/dto/ModifyStatusRequest.kt
@@ -1,0 +1,8 @@
+package org.heeheepresso.menu.interfaces.dto
+
+import org.heeheepresso.menu.domain.menu.model.MenuStatus
+
+data class ModifyStatusRequest (
+    var status: MenuStatus
+        ){
+}

--- a/menu/src/test/kotlin/org/heeheepresso/menu/domain/menu/service/MenuServiceTests.kt
+++ b/menu/src/test/kotlin/org/heeheepresso/menu/domain/menu/service/MenuServiceTests.kt
@@ -1,0 +1,167 @@
+package org.heeheepresso.menu.domain.menu.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import org.heeheepresso.menu.domain.menu.model.*
+import io.kotest.matchers.shouldBe
+import org.heeheepresso.menu.interfaces.dto.ModifyStatusRequest
+import org.springframework.boot.test.context.SpringBootTest
+import java.math.BigDecimal
+
+
+@SpringBootTest
+class MenuServiceTests (
+    val menuService: MenuService
+        ) : BehaviorSpec({
+        Given("메뉴 서비스를 테스트") {
+            When("메뉴에 아무것도 없을 때") {
+                val result = menuService.findAll()
+
+                Then("메뉴 리스트 전체 조회") {
+                    result.shouldHaveSize(0)
+                }
+            }
+            When("메뉴를 저장하면") {
+
+                val detail = MenuItemDetail(
+                    temperature = Temperature.ICE,
+                    thumbnailUrl = "https://github.com/HeeHeePresso/Backend/assets/49651099/7febfe0c-4aa9-47c1-8e74-cac555327349",
+                )
+                val price = MenuItemPrice(
+                    storePrice = BigDecimal("2500.00"),
+                    salePrice = BigDecimal("2500.00"),
+                    takeOutPrice = BigDecimal("1800.00"),
+                )
+                //given
+                val request = Menu(
+                    menuId = null,
+                    title = "아메리카노",
+                    subTitle = "Americano",
+                    description = "[진함 고소함] 견과류 풍미와 초콜릿처럼 달콤 쌉싸름한 맛이 밸런스 있게 어우러진 균형잡힌 바디감의 커피",
+                    category = Category.COFFEE,
+                    flagType = null,
+                    status = MenuStatus.SELLING,
+                    menuItemDetail = detail,
+                    menuItemPrice = price,
+                )
+                //when
+                val result = menuService.save(request)
+                Then("메뉴를 저장한다") {
+                    result.menuId shouldBe request.menuId
+                    result.title shouldBe request.title
+                    result.subTitle shouldBe request.subTitle
+                    result.description shouldBe request.description
+                    result.category shouldBe request.category
+                    result.flagType shouldBe request.flagType
+                    result.status shouldBe request.status
+                    result.menuItemDetail shouldBe request.menuItemDetail
+                    result.menuItemPrice shouldBe request.menuItemPrice
+                }
+            }
+
+            When("메뉴 한건을 조회하면") {
+                val detail = MenuItemDetail(
+                    temperature = Temperature.ICE,
+                    thumbnailUrl = "https://github.com/HeeHeePresso/Backend/assets/49651099/7febfe0c-4aa9-47c1-8e74-cac555327349",
+                )
+                val price = MenuItemPrice(
+                    storePrice = BigDecimal("2500.00"),
+                    salePrice = BigDecimal("2500.00"),
+                    takeOutPrice = BigDecimal("1800.00"),
+                )
+                //given
+                val input = Menu(
+                    menuId = 2L,
+                    title = "아메리카노",
+                    subTitle = "Americano",
+                    description = "[진함 고소함] 견과류 풍미와 초콜릿처럼 달콤 쌉싸름한 맛이 밸런스 있게 어우러진 균형잡힌 바디감의 커피",
+                    category = Category.COFFEE,
+                    flagType = null,
+                    status = MenuStatus.SELLING,
+                    menuItemDetail = detail,
+                    menuItemPrice = price,
+                )
+                val savedInput = menuService.save(input)
+                //when
+                val result = menuService.findById(savedInput.menuId!!)
+
+                Then("조회한 메뉴아이디를 반환") {
+                    result.menuId shouldBe input.menuId
+                    result.title shouldBe input.title
+                    result.subTitle shouldBe input.subTitle
+                    result.description shouldBe input.description
+                    result.category shouldBe input.category
+                    result.flagType shouldBe input.flagType
+                    result.status shouldBe input.status
+                    result.menuItemDetail shouldBe input.menuItemDetail
+                    result.menuItemPrice shouldBe input.menuItemPrice
+                }
+            }
+
+            When("메뉴를 전체 조회하면") {
+                val detail = MenuItemDetail(
+                    temperature = Temperature.ICE,
+                    thumbnailUrl = "https://github.com/HeeHeePresso/Backend/assets/49651099/7febfe0c-4aa9-47c1-8e74-cac555327349",
+                )
+                val price = MenuItemPrice(
+                    storePrice = BigDecimal("2500.00"),
+                    salePrice = BigDecimal("2500.00"),
+                    takeOutPrice = BigDecimal("1800.00"),
+                )
+                //given
+                val input = Menu(
+                    menuId = 3L,
+                    title = "아메리카노",
+                    subTitle = "Americano",
+                    description = "[진함 고소함] 견과류 풍미와 초콜릿처럼 달콤 쌉싸름한 맛이 밸런스 있게 어우러진 균형잡힌 바디감의 커피",
+                    category = Category.COFFEE,
+                    flagType = null,
+                    status = MenuStatus.SELLING,
+                    menuItemDetail = detail,
+                    menuItemPrice = price,
+                )
+                menuService.save(input)
+
+                val result = menuService.findAll()
+
+                Then("메뉴 리스트 전체 조회") {
+                    result.shouldHaveSize(3)
+                }
+            }
+            When("상태 수정"){
+                val detail = MenuItemDetail(
+                    temperature = Temperature.ICE,
+                    thumbnailUrl = "https://github.com/HeeHeePresso/Backend/assets/49651099/7febfe0c-4aa9-47c1-8e74-cac555327349",
+                )
+                val price = MenuItemPrice(
+                    storePrice = BigDecimal("2500.00"),
+                    salePrice = BigDecimal("2500.00"),
+                    takeOutPrice = BigDecimal("1800.00"),
+                )
+                //given
+                val input = Menu(
+                    menuId = 3L,
+                    title = "아메리카노",
+                    subTitle = "Americano",
+                    description = "[진함 고소함] 견과류 풍미와 초콜릿처럼 달콤 쌉싸름한 맛이 밸런스 있게 어우러진 균형잡힌 바디감의 커피",
+                    category = Category.COFFEE,
+                    flagType = null,
+                    status = MenuStatus.SELLING,
+                    menuItemDetail = detail,
+                    menuItemPrice = price,
+                )
+                menuService.save(input)
+
+                val request = ModifyStatusRequest(
+                    status = MenuStatus.SOLD_OUT,
+                )
+                val result = menuService.modifyStatus(3L, request)
+
+                Then("메뉴 상태 변경"){
+                    result.status shouldBe request.status
+                }
+            }
+
+        }
+        })
+


### PR DESCRIPTION
### 개발 사항
- 메뉴 등록 api 추가
- 메뉴 조회 api 추가
- 메뉴 상태 수정 api 추가

+kotest 사용으로 인한 dependency 추가

### 리뷰 포인트
**참고사항**
1. 메뉴 수정의 경우 화면이 먼저 or 어떻게 수정하는 것이 좋을지 고민 해봐야 될 것 같아서 상태 수정만 만들었습니다.
2. 우선 개발 후 코드리뷰를 통해 개선하기 위해 pr 올렸습니다. (깊은 생각을 하지 않았다는 뜻...)
3. 영양정보의 경우 정확히 하고 추가하고 싶어 추가하지 않았습니다.


**고민사항**
1. 수정 시 어떤 단어를 쓸지 (modify라는 용어를 사용하는게 맞을지, 상태의 경우 update? change?)
2. 영양정보를 추가한다면 Menu내 MenuItemDetail VO내 Nutrition information VO 로 만들고 싶은데 이게 과연 좋은 방법일까요..?
3. hot||ice 와 관련돼서 enum으로 관리하고 싶어서 넣었는데 고민하다가 해당 enum을 temperature로 만들었습니다... 괜찮은지 아니면 더 좋은 네이밍 있으면 추천해주세요,,, 혹은 더좋은 다른 개발법


(재영님 외 다른분들을 리뷰어로 넣은 이유는 그냥 코드에 대한 더 많은 리뷰를 받고 싶어서 넣은거니 굳이 확인 안해주셔두 됩니다!~)