### PR TITLE
[GW] fix: 메뉴 서비스와의 통신 구축

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -44,9 +44,6 @@ dependencies {
     // spring cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-mvc'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-
-//    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/GatewayApplication.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/GatewayApplication.kt
@@ -3,17 +3,15 @@ package org.heeheepresso.gateway
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient
 import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
 @EnableEurekaServer
-@EnableDiscoveryClient
 @EnableCaching
 @EnableJpaAuditing
 class GatewayApplication
 
 fun main(args: Array<String>) {
-	runApplication<GatewayApplication>(*args)
+    runApplication<GatewayApplication>(*args)
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/common/EurekaClient.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/common/EurekaClient.kt
@@ -1,0 +1,44 @@
+package org.heeheepresso.gateway.common
+
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+@Component
+class EurekaClient(
+        private val webClientBuilder: WebClient.Builder
+) {
+    companion object {
+        private const val EUREKA_URL = "http://localhost:8761/eureka"
+    }
+
+    suspend fun discoverServiceByName(serviceName: String): String {
+        discoveryClient(serviceName)
+                .get()
+                .retrieve()
+                .bodyToMono(String::class.java)
+                .map { parseServiceUrl(it) }
+                .block()?.let {
+                    return it
+                }
+        throw IllegalStateException("존재하지 않는 서비스입니다.")
+    }
+
+    private fun discoveryClient(serviceName: String): WebClient {
+        return this.webClientBuilder
+                .baseUrl("$EUREKA_URL/apps/$serviceName")
+                .build()
+    }
+
+    private fun parseServiceUrl(xml: String): String? {
+        val startTag = "<homePageUrl>"
+        val endTag = "/</homePageUrl>"
+
+        val startIndex = xml.indexOf(startTag)
+        val endIndex = xml.indexOf(endTag, startIndex)
+
+        if (startIndex == -1 || endIndex == -1)
+            return null
+
+        return xml.substring(startIndex + startTag.length, endIndex)
+    }
+}

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/common/EurekaClientService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/common/EurekaClientService.kt
@@ -1,10 +1,10 @@
 package org.heeheepresso.gateway.common
 
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 
-@Component
-class EurekaClient(
+@Service
+class EurekaClientService(
         private val webClientBuilder: WebClient.Builder
 ) {
     companion object {

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/config/webclient/WebClientConfig.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/config/webclient/WebClientConfig.kt
@@ -1,16 +1,9 @@
 package org.heeheepresso.gateway.config.webclient
 
-import io.netty.channel.ChannelOption
-import io.netty.handler.timeout.ReadTimeoutHandler
-import io.netty.handler.timeout.WriteTimeoutHandler
-import org.springframework.cloud.client.loadbalancer.LoadBalanced
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
-import reactor.netty.http.client.HttpClient
-import java.time.Duration
-import java.util.concurrent.TimeUnit
+
 
 @Configuration
 class WebClientConfig {
@@ -19,7 +12,6 @@ class WebClientConfig {
     }
 
     @Bean
-    @LoadBalanced
     fun webClientBuilder(): WebClient.Builder {
         return WebClient.builder()
     }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/MenuCategory.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/MenuCategory.kt
@@ -1,10 +1,12 @@
 package org.heeheepresso.gateway.menu.category
 
 enum class MenuCategory {
-    SET_MENU,
     COFFEE,
-    DECAFFINE_COFFEE,
-    BANACCINO_AND_SMOOTHIE,
-    TEA_AND_ADE,
-    BREAD_AND_DESSERT
+    DECAFFEINE_COFFEE,
+    MILK_TEA_AND_LATTE,
+    JUICE_AND_DRINK,
+    TEA_AMD_ADE,
+    BREAD,
+    DESSERT,
+    MD,
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/detail/MenuDetailService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/detail/MenuDetailService.kt
@@ -1,13 +1,8 @@
 package org.heeheepresso.gateway.menu.detail
 
-import com.google.common.collect.ImmutableList
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.reactor.awaitSingleOrNull
-import org.heeheepresso.gateway.common.response.MenuApiStatus
 import org.heeheepresso.gateway.common.response.MenuApiStatus.*
-import org.heeheepresso.gateway.menu.category.MenuCategory
 import org.heeheepresso.gateway.menu.detail.client.MenuDetailController
-import org.heeheepresso.gateway.menu.domain.MenuBase
 import org.heeheepresso.gateway.menu.domain.MenuInfo
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/detail/client/MenuDetailController.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/detail/client/MenuDetailController.kt
@@ -1,5 +1,6 @@
 package org.heeheepresso.gateway.menu.detail.client
 
+import org.heeheepresso.gateway.common.EurekaClientService
 import org.heeheepresso.gateway.common.response.MenuApiResponse
 import org.heeheepresso.gateway.menu.domain.MenuInfo
 import org.springframework.core.ParameterizedTypeReference
@@ -9,7 +10,8 @@ import reactor.core.publisher.Mono
 
 @RestController
 class MenuDetailController(
-        private val webClientBuilder: WebClient.Builder
+        private val webClientBuilder: WebClient.Builder,
+        private val eurekaClientService: EurekaClientService
 ) {
 
     companion object {
@@ -17,7 +19,8 @@ class MenuDetailController(
     }
 
     suspend fun callMenuInfo(menuIds: List<Long>): Mono<MenuApiResponse<List<MenuInfo>>> {
-        return client().get()
+        return client()
+                .get()
                 .uri {
                     it.path("/menus")
                             .queryParam("id", menuIds)
@@ -27,9 +30,9 @@ class MenuDetailController(
                 .bodyToMono(object : ParameterizedTypeReference<MenuApiResponse<List<MenuInfo>>>() {})
     }
 
-    private fun client(): WebClient {
+    private suspend fun client(): WebClient {
         return this.webClientBuilder
-                .baseUrl("http://${SERVICE_NAME}")
+                .baseUrl(eurekaClientService.discoverServiceByName(SERVICE_NAME))
                 .build()
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/domain/MenuInfo.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/domain/MenuInfo.kt
@@ -4,13 +4,13 @@ import org.heeheepresso.gateway.menu.category.MenuCategory
 
 data class MenuInfo(
         val id: Long,
-        var price: String,
         var name: String,
-        var category: MenuCategory,
+        var price: String,
         var thumbnailImageUrl: String,
+        var category: MenuCategory,
         var subTitle: String,
 ) {
-    constructor(menuId: Long) : this(menuId, "0원", "", MenuCategory.SET_MENU, "", "")
+    constructor(menuId: Long) : this(menuId, "", "0원", "", MenuCategory.COFFEE, "")
 
     fun getBaseInfo(): MenuBase {
         return MenuBase(

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationService.kt
@@ -47,12 +47,16 @@ class RecommendationService(
     }
 
     private suspend fun getRecommendedMenu(request: RecommendedRequest): RecommendationResult {
-        val recommendMenus = recommendController.callHomeRecommendMenus(request)
-        val response = recommendMenus.awaitSingle()
-
-        if (response.success) {
-            return response.data
-        }
-        return RecommendationResult()
+//        val recommendMenus = recommendController.callHomeRecommendMenus(request)
+//        val response = recommendMenus.awaitSingle()
+//
+//        if (response.success) {
+//            return response.data
+//        }
+//        return RecommendationResult()
+        return RecommendationResult(
+                recommendedMenus = ImmutableList.of(RecommendedMenu(1L), RecommendedMenu(3L)),
+                handler = if (request.handler == "HOME") "SEASON_RECOMMENDED" else request.handler
+        )
     }
 }

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -3,21 +3,21 @@ server:
 
 eureka:
   instance:
-    hostname: 127.0.0.1
+    hostname: localhost
   client:
     registerWithEureka: false
     fetchRegistry: false
   server:
     serverUrl:
-      defaultZone: http://127.0.0.1:8761/eureka/
+      defaultZone: http://localhost:8761/eureka/
 
 spring:
   datasource:
-      driver-class-name: org.h2.Driver
-      url: jdbc:h2:mem:testdb
-      username: sa
-      password:
-#    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+  #    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: create
@@ -25,10 +25,10 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
-#  data:
-#    redis:
-#      host: localhost
-#      port: 6379
+  #  data:
+  #    redis:
+  #      host: localhost
+  #      port: 6379
   application:
     name: gateway
   cloud:


### PR DESCRIPTION
## Related Issue
close #49 
close #55

## 변경사항
- 어제(4월 14일 통합테스트) 발생했던 유레카 통신 문제를 해결
  - application.yml에 유레카의 호스트 이름을 명시적인 IP가 아닌 localhost로 변경
- 메뉴 서비스와의 통신을 위한 메뉴카테고리 재정의
- 임시로 추천 통신 모킹으로 변경
- 공통적으로 다양한 서비스와의 통신을 위한 EurekaClientService 정의
  - 여기서 파라미터로 받은 서비스 이름에 대한 실제 정보를 REST API로 조회하고 반환
    - 없는 서비스의 경우 nullable하기에 그 처리를 위해 우선 exception 처리함
  - 결과 값이 xml이여서 파싱

<img width="1117" alt="스크린샷 2024-04-15 오후 5 22 43" src="https://github.com/HeeHeePresso/Backend/assets/54919474/51b153b8-7194-45b3-b45e-7fc33632bdc9">

- /home API로 호출한 결과

## TroubleShooting
- 처음에 통신이 되었을 때 실제 data 값만 받아와지지 않는 문제 발생
- 제네릭 타입의 문제인가 싶어 Any로 변경하니 잘 들어옴
  - bodyToMono로 받을 때 복잡한 구조인 경우(e.g. 제네릭 타입) `object : ParameterizedTypeReference<MenuApiResponse<List<MenuInfo>>>() {}` 으로 전달(코틀린 기준)
  - 그래서 List<MenuInfo> 타입의 필드 순서 문제인가 싶어 메뉴서비스에서 제공하는 dto 필드 순서 싱크맞춤

- WebClient는 비동기 통신, FeignClient 동기 통신이여서 WebClient 채택.
- FeignClient는 서비스 디스커버리를 지원하지만 WebClient는 그러지 않아서 서비스명만으로 통신이 불가능하다.
  - 503 에러, 404 에러 
- 그래서 WebClient를 사용할 때는 유레카 서버에 특정 서비스의 정보를 조회하는 API를 호출해 정보를 가져와 해당 url로 요청
을 보내야했다.

<img width="636" alt="스크린샷 2024-04-15 오후 5 21 53" src="https://github.com/HeeHeePresso/Backend/assets/54919474/bc92e002-8962-41f6-8f80-d3f9474bff87">

- 정보 조회 결과
- LoadBalanced 어노테이션을 붙이니 문제가 발생해서 삭제함.