### PR TITLE
[GW] refactor: 홈 화면 API에 대한 추천 서비스 통신 연동

### DIFF
--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/config/WebClientConfig.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/config/WebClientConfig.kt
@@ -32,6 +32,15 @@ class WebClientConfig(
                 .build()
     }
 
+    @Bean
+    fun recommendWebClient(): WebClient {
+        return WebClient.builder()
+                .clientConnector(ReactorClientHttpConnector(this.httpClient()))
+                .baseUrl(RECOMMEND_SERVICE_URL)
+                .exchangeStrategies(this.exchangeStrategies())
+                .build()
+    }
+
     private fun httpClient() = HttpClient.create()
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, TIMEOUT_MILLIS.toInt())
             .responseTimeout(Duration.ofMillis(TIMEOUT_MILLIS))

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/RecommendationService.kt
@@ -1,9 +1,8 @@
 package org.heeheepresso.gateway.recommendation
 
-import com.google.common.collect.ImmutableList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.heeheepresso.gateway.common.Context
 import org.heeheepresso.gateway.menu.category.RecommendationFilterUtils.Companion.addCategoryFilter
 import org.heeheepresso.gateway.menu.moreinfo.MoreInfo
@@ -47,16 +46,11 @@ class RecommendationService(
     }
 
     private suspend fun getRecommendedMenu(request: RecommendedRequest): RecommendationResult {
-//        val recommendMenus = recommendController.callHomeRecommendMenus(request)
-//        val response = recommendMenus.awaitSingle()
-//
-//        if (response.success) {
-//            return response.data
-//        }
-//        return RecommendationResult()
-        return RecommendationResult(
-                recommendedMenus = ImmutableList.of(RecommendedMenu(1L), RecommendedMenu(3L)),
-                handler = if (request.handler == "HOME") "SEASON_RECOMMENDED" else request.handler
-        )
+        val recommendMenus = recommendController.callHomeRecommendMenus(request)
+        val response = recommendMenus.awaitSingleOrNull() ?: return RecommendationResult()
+        if (response.success) {
+            return response.data
+        }
+        return RecommendationResult()
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/client/ErrorResponse.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/client/ErrorResponse.kt
@@ -1,9 +1,7 @@
 package org.heeheepresso.gateway.recommendation.client
 
-import org.apache.http.HttpStatus
-
 data class ErrorResponse(
-        val httpStatus: HttpStatus,
+//        val httpStatus: HttpStatus,
         val code: Int,
         val message: String
 )

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/client/HomeRecommendResponse.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/recommendation/client/HomeRecommendResponse.kt
@@ -4,7 +4,7 @@ import org.heeheepresso.gateway.recommendation.RecommendationResult
 
 data class HomeRecommendResponse(
         val success: Boolean,
-        val error: List<ErrorResponse>,
-        val timestamp: String,
-        val data: RecommendationResult
+        val data: RecommendationResult,
+        val error: ErrorResponse?,
+        val timestamp: String
 )

--- a/recommend/src/main/resources/application.yml
+++ b/recommend/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 0
+  port: 8082
 
 spring:
   application:


### PR DESCRIPTION
## Related Issue
close #84 

## 변경사항
- 추천 서비스의 WebClient 정의
  - 요청 바디 보낼 때 WebFlux 연동을 위해 Mono.just(requestBody)로 전달해야하네요. 'producer' type is unknow when I return value in the response body 에러 발생
- 추천 서비스 포트를  명시(8082)했습니다. @Cho-El 
- 추천 홈 화면 API에대한 응답 폼이 맞지 않아 데이터 싱크와 error 필드를 nullable로 변경

---
- 게이트웨이 & 메뉴 서비스 & 추천 서비스 서버 실행 후, 홈 화면 API 테스트 성공
  - 추천 서비스 또는 메뉴 서비스가 fail 났다는 가정하에, {게이트웨이 On, 메뉴 On, 추천 Off} & {게이트웨이 On, 메뉴 Off, 추천 On} 상태에서 요청에 빈 응답 값 테스트도 완료
```json
{
    "resultCode": 0,
    "resultMessage": "요청 성공",
    "data": {
        "eventUrls": [
            "https://github.com/HeeHeePresso/Backend/assets/49651099/7febfe0c-4aa9-47c1-8e74-cac555327349",
            "https://github.com/HeeHeePresso/Backend/assets/49651099/7febfe0c-4aa9-47c1-8e74-cac555327349",
            "https://github.com/HeeHeePresso/Backend/assets/49651099/7febfe0c-4aa9-47c1-8e74-cac555327349"
        ],
        "menuInfos": [
            {
                "handler": "String",
                "menus": [
                    {
                        "id": 1,
                        "name": "메뉴01",
                        "price": "2500원",
                        "thumbnailImageUrl": "https://github.com/HeeHeePresso/Backend/assets/49651099/58dca505-0a34-4926-a0aa-336a91c864c9"
                    },
                    {
                        "id": 2,
                        "name": "메뉴02",
                        "price": "2500원",
                        "thumbnailImageUrl": "https://github.com/HeeHeePresso/Backend/assets/49651099/2ba003c2-ddd6-41cf-bb7e-e3a18b7e2eec"
                    }
                ]
            }
        ]
    }
}
```
