### PR TITLE
[GW] feat: 카테고리 별 메뉴 목록 조회 API 구현

### DIFF
--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/common/extension/StringExtension.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/common/extension/StringExtension.kt
@@ -1,7 +1,7 @@
 package org.heeheepresso.gateway.common.extension
 
 import org.heeheepresso.gateway.menu.category.MenuCategory
-import org.heeheepresso.gateway.search.request.SearchRequestHandler
+import org.heeheepresso.gateway.search.request.SearchRequestHandler.MENU_CATEGORY
 import org.heeheepresso.gateway.search.request.SearchRequestHandler.HOME
 
 class StringExtension {
@@ -15,6 +15,8 @@ internal fun String.getMenuCategory(): MenuCategory {
 internal fun String.convertRecommendedUrl(): String {
     return when(this) {
         HOME.name -> "/home/recommend"
+//        MENU_CATEGORY.name -> "/menu/category/recommend"
+        MENU_CATEGORY.name -> "/home/recommend" // 테스트 때문에 임시로
         else -> ""
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/home/HomeService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/home/HomeService.kt
@@ -16,11 +16,11 @@ import org.springframework.stereotype.Service
 
 @Service
 class HomeService(
-    private val searcherService: SearcherService,
-    private val userInfoContextElaborator: UserInfoContextElaborator,
-    private val menuDetailSearchProcessor: MenuDetailSearchProcessor,
-    private val eventSearchQuery: EventSearchQuery,
-    private val homeRecommendationSearchQuery: HomeRecommendationSearchQuery,
+        private val searcherService: SearcherService,
+        private val userInfoContextElaborator: UserInfoContextElaborator,
+        private val menuDetailSearchProcessor: MenuDetailSearchProcessor,
+        private val eventSearchQuery: EventSearchQuery,
+        private val homeRecommendationSearchQuery: HomeRecommendationSearchQuery,
 ) {
     suspend fun getHomeData(userId: Long): HomePageResponse {
         val response = searcherService.search(buildSearchContext(userId))
@@ -29,11 +29,11 @@ class HomeService(
 
     private fun buildSearchContext(userId: Long): SearchContext {
         return SearchContext(
-            UserInfo(userId = userId),
-            searchRequestType = SearchRequestType.HOME,
-            contextElaborators = ImmutableList.of(userInfoContextElaborator),
-            searchQueries = ImmutableList.of(eventSearchQuery, homeRecommendationSearchQuery),
-            postProcessors = ImmutableList.of(menuDetailSearchProcessor)
+                UserInfo(userId = userId),
+                searchRequestType = SearchRequestType.HOME,
+                contextElaborators = ImmutableList.of(userInfoContextElaborator),
+                searchQueries = ImmutableList.of(eventSearchQuery, homeRecommendationSearchQuery),
+                postProcessors = ImmutableList.of(menuDetailSearchProcessor)
         )
     }
 
@@ -42,41 +42,42 @@ class HomeService(
     }
 
     private fun getEventUrls(response: SearchResponse): List<String> {
-        val result = response.results
-            .filter { it.searcherType == EVENT }
-            .firstOrNull { it.searchRequestHandler == HOME }
-        if (result?.imageUrls == null) {
-            return emptyList()
-        }
-
-        return result.imageUrls
+//        val result = response.results
+//            .filter { it.searcherType == EVENT }
+//            .firstOrNull { it.searchRequestHandler == HOME }
+//        if (result?.imageUrls == null) {
+//            return emptyList()
+//        }
+        return response.getResultBy<String>(searcherType = EVENT, searchRequestHandler = HOME)
+//        return result.imageUrls
     }
 
     private fun getMenuResult(response: SearchResponse): List<MenuResult> {
-        val menuDetailMap = response.extra.getOrDefault(MENU_DETAIL_IDS, emptyList())
-            .filterIsInstance<MenuInfo>()
-            .associateBy { it.id }
-        if (menuDetailMap.isEmpty()) {
-            return emptyList()
-        }
+//        val menuDetailMap = response.extra.getOrDefault(MENU_DETAIL_IDS, emptyList())
+//            .filterIsInstance<MenuInfo>()
+//            .associateBy { it.id }
+//        if (menuDetailMap.isEmpty()) {
+//            return emptyList()
+//        }
+//
+//        val results = response.results
+//            .filter { it.searcherType == RECOMMENDATION }
+//            .firstOrNull { it.searchRequestHandler == HOME }
+//        if (results?.menuIds == null) {
+//            return emptyList()
+//        }
 
-        val results = response.results
-            .filter { it.searcherType == RECOMMENDATION }
-            .firstOrNull { it.searchRequestHandler == HOME }
-        if (results?.menuIds == null) {
-            return emptyList()
-        }
-
-        val menuBaseList =
-            results.menuIds.map { menuDetailMap.getOrDefault(it, MenuInfo(it)) }
-            .map {
-                MenuBase(
-                    id = it.id,
-                    name = it.name,
-                    price = it.price,
-                    thumbnailImageUrl = it.thumbnailImageUrl
-                )
-            }
-        return ImmutableList.of(MenuResult(HOME.name, menuBaseList))
+//        val menuBaseList =
+//            results.menuIds.map { menuDetailMap.getOrDefault(it, MenuInfo(it)) }
+//            .map {
+//                MenuBase(
+//                    id = it.id,
+//                    name = it.name,
+//                    price = it.price,
+//                    thumbnailImageUrl = it.thumbnailImageUrl
+//                )
+//            }
+        val menuBases = response.getResultBy<MenuBase>(searcherType = RECOMMENDATION, searchRequestHandler = HOME)
+        return ImmutableList.of(MenuResult(HOME.name, menuBases))
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/CategoryMenusResponse.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/CategoryMenusResponse.kt
@@ -1,0 +1,8 @@
+package org.heeheepresso.gateway.menu.category
+
+import org.heeheepresso.gateway.home.MenuResult
+
+data class CategoryMenusResponse(
+        val menuCategory: MenuCategory,
+        val menuInfos: List<MenuResult>
+)

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/MenuCategory.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/MenuCategory.kt
@@ -1,6 +1,7 @@
 package org.heeheepresso.gateway.menu.category
 
 enum class MenuCategory {
+    RECOMMENDATION,
     COFFEE,
     DECAFFEINE_COFFEE,
     MILK_TEA_AND_LATTE,

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/controller/MenuCategoryController.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/controller/MenuCategoryController.kt
@@ -1,0 +1,21 @@
+package org.heeheepresso.gateway.menu.category.controller
+
+import org.heeheepresso.gateway.common.response.GatewayResponse
+import org.heeheepresso.gateway.menu.category.CategoryMenusResponse
+import org.heeheepresso.gateway.menu.category.MenuCategory
+import org.heeheepresso.gateway.menu.category.service.MenuCategoryService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+class MenuCategoryController(
+        private val menuCategoryService: MenuCategoryService
+) {
+
+    @GetMapping("/menus")
+    suspend fun getMenusByCategory(@RequestParam("category") menuCategory: MenuCategory, @RequestParam("userId") userId: Long): GatewayResponse<CategoryMenusResponse> {
+        return GatewayResponse(menuCategoryService.getMenusByCategory(menuCategory, userId))
+    }
+}

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/service/MenuCategoryService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/service/MenuCategoryService.kt
@@ -1,0 +1,49 @@
+package org.heeheepresso.gateway.menu.category.service
+
+import com.google.common.collect.ImmutableList
+import org.heeheepresso.gateway.context.UserInfoContextElaborator
+import org.heeheepresso.gateway.home.MenuResult
+import org.heeheepresso.gateway.menu.category.CategoryMenusResponse
+import org.heeheepresso.gateway.menu.category.MenuCategory
+import org.heeheepresso.gateway.menu.domain.MenuBase
+import org.heeheepresso.gateway.processor.post.MenuDetailSearchProcessor
+import org.heeheepresso.gateway.search.*
+import org.heeheepresso.gateway.search.query.MenuCategoryRecommendationSearchQuery
+import org.springframework.stereotype.Service
+import org.heeheepresso.gateway.search.request.SearchRequestHandler.*
+import org.heeheepresso.gateway.search.searcher.SearcherType.*
+
+
+@Service
+class MenuCategoryService(
+        private val searcherService: SearcherService,
+        private val userInfoContextElaborator: UserInfoContextElaborator,
+        private val menuDetailSearchProcessor: MenuDetailSearchProcessor,
+        private val menuCategoryRecommendationSearchQuery: MenuCategoryRecommendationSearchQuery
+) {
+
+    suspend fun getMenusByCategory(menuCategory: MenuCategory, userId: Long): CategoryMenusResponse {
+        val response = searcherService.search(buildSearchContext(userId, menuCategory))
+        return buildResponse(category = menuCategory, response = response)
+    }
+
+    private fun buildSearchContext(userId: Long, category: MenuCategory): SearchContext {
+        return SearchContext(
+                UserInfo(userId = userId),
+                searchRequestType = SearchRequestType.HOME,
+                contextElaborators = ImmutableList.of(userInfoContextElaborator),
+                searchQueries = ImmutableList.of(menuCategoryRecommendationSearchQuery),
+                postProcessors = ImmutableList.of(menuDetailSearchProcessor),
+                category = category
+        )
+    }
+
+    private fun buildResponse(category: MenuCategory, response: SearchResponse): CategoryMenusResponse {
+        return CategoryMenusResponse(category, getMenuResult(response))
+    }
+
+    private fun getMenuResult(response: SearchResponse): List<MenuResult> {
+        val menuBases = response.getResultBy<MenuBase>(searcherType = RECOMMENDATION, searchRequestHandler = MENU_CATEGORY)
+        return ImmutableList.of(MenuResult(MENU_CATEGORY.name, menuBases))
+    }
+}

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/processor/post/MenuDetailSearchProcessor.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/processor/post/MenuDetailSearchProcessor.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.coroutineScope
 import org.heeheepresso.gateway.menu.detail.MenuDetailService
 import org.heeheepresso.gateway.menu.domain.MenuBase
 import org.heeheepresso.gateway.search.SearchResponse
-import org.heeheepresso.gateway.search.SearchResponse.Companion.MENU_DETAIL_IDS
+import org.heeheepresso.gateway.search.searcher.SearcherType
 import org.springframework.stereotype.Service
 
 @Service
@@ -13,13 +13,19 @@ class MenuDetailSearchProcessor(
         private val menuDetailService: MenuDetailService
 ) : PostProcessor {
 
-    override suspend fun process(response: SearchResponse): List<Any> {
+    override suspend fun process(response: SearchResponse) {
         return coroutineScope {
             val menuDetails = async {
                 menuDetailService.getMenuDetails(response.getTotalMenuIds())
             }.await()
-            //response.extra[MENU_DETAIL_IDS] = menuDetails
-            menuDetails.map { MenuBase(it.id, it.name, it.price, it.thumbnailImageUrl) }
+            response.results
+                    .first { it.searcherType == SearcherType.RECOMMENDATION }
+                    .searched = menuDetails.map {
+                MenuBase(it.id,
+                        it.name,
+                        it.price,
+                        it.thumbnailImageUrl)
+            }
         }
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/processor/post/MenuDetailSearchProcessor.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/processor/post/MenuDetailSearchProcessor.kt
@@ -3,20 +3,23 @@ package org.heeheepresso.gateway.processor.post
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.heeheepresso.gateway.menu.detail.MenuDetailService
+import org.heeheepresso.gateway.menu.domain.MenuBase
 import org.heeheepresso.gateway.search.SearchResponse
 import org.heeheepresso.gateway.search.SearchResponse.Companion.MENU_DETAIL_IDS
 import org.springframework.stereotype.Service
 
 @Service
 class MenuDetailSearchProcessor(
-    private val menuDetailService: MenuDetailService
-): PostProcessor {
+        private val menuDetailService: MenuDetailService
+) : PostProcessor {
 
-    override suspend fun process(response: SearchResponse) {
+    override suspend fun process(response: SearchResponse): List<Any> {
         return coroutineScope {
             val menuDetails = async {
-                menuDetailService.getMenuDetails(response.getTotalMenuIds()) }.await()
-            response.extra[MENU_DETAIL_IDS] = menuDetails
+                menuDetailService.getMenuDetails(response.getTotalMenuIds())
+            }.await()
+            //response.extra[MENU_DETAIL_IDS] = menuDetails
+            menuDetails.map { MenuBase(it.id, it.name, it.price, it.thumbnailImageUrl) }
         }
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/processor/post/PostProcessor.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/processor/post/PostProcessor.kt
@@ -4,5 +4,5 @@ import org.heeheepresso.gateway.search.SearchResponse
 
 interface PostProcessor {
 
-    suspend fun process(response: SearchResponse): List<Any>
+    suspend fun process(response: SearchResponse)
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/processor/post/PostProcessor.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/processor/post/PostProcessor.kt
@@ -4,5 +4,5 @@ import org.heeheepresso.gateway.search.SearchResponse
 
 interface PostProcessor {
 
-    suspend fun process(response: SearchResponse)
+    suspend fun process(response: SearchResponse): List<Any>
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearchContext.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearchContext.kt
@@ -1,15 +1,17 @@
 package org.heeheepresso.gateway.search
 
 import org.heeheepresso.gateway.context.ContextElaborator
+import org.heeheepresso.gateway.menu.category.MenuCategory
 import org.heeheepresso.gateway.processor.post.PostProcessor
 import org.heeheepresso.gateway.search.query.SearchQuery
 
 data class SearchContext(
-    private var userInfo: UserInfo,
-    val searchRequestType: SearchRequestType,
-    val contextElaborators: List<ContextElaborator>,
-    val searchQueries: List<SearchQuery>,
-    val postProcessors: List<PostProcessor>,
+        private var userInfo: UserInfo,
+        val searchRequestType: SearchRequestType,
+        val contextElaborators: List<ContextElaborator>,
+        val searchQueries: List<SearchQuery>,
+        val postProcessors: List<PostProcessor>,
+        val category: MenuCategory? = null
 ) {
     fun decorateUserInfo(userId: Long, storeId: Long) {
         this.userInfo = UserInfo(userId = userId, storeId = storeId)

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearchResponse.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearchResponse.kt
@@ -12,7 +12,8 @@ data class SearchResponse(
     }
 
     fun getTotalMenuIds(): List<Long> {
-        return results.mapNotNull { it.searched }.filterIsInstance<List<Long>>().flatten()
+        return results.first { it.searcherType == SearcherType.RECOMMENDATION }.searched?.filterIsInstance<Long>()
+                ?: emptyList()
     }
 
     inline fun <reified T> getResultBy(searcherType: SearcherType, searchRequestHandler: SearchRequestHandler): List<T> {

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearchResponse.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearchResponse.kt
@@ -1,14 +1,24 @@
 package org.heeheepresso.gateway.search
 
+import org.heeheepresso.gateway.search.request.SearchRequestHandler
+import org.heeheepresso.gateway.search.searcher.SearcherType
+
 data class SearchResponse(
-    val results: List<SearchResult>,
-    val extra: MutableMap<String, List<Any>> = HashMap(),
+        val results: List<SearchResult>,
+//    val extra: MutableMap<String, List<Any>> = HashMap(),
 ) {
     companion object {
         const val MENU_DETAIL_IDS = "menuDetailIds"
     }
 
     fun getTotalMenuIds(): List<Long> {
-        return results.mapNotNull { it.menuIds }.flatten()
+        return results.mapNotNull { it.searched }.filterIsInstance<List<Long>>().flatten()
+    }
+
+    inline fun <reified T> getResultBy(searcherType: SearcherType, searchRequestHandler: SearchRequestHandler): List<T> {
+        val result = this.results
+                .filter { it.searcherType == searcherType }
+                .firstOrNull { it.searchRequestHandler == searchRequestHandler }
+        return result?.searched?.filterIsInstance<T>() ?: emptyList()
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearchResult.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearchResult.kt
@@ -8,6 +8,7 @@ data class SearchResult(
     val statusCode: StatusCode,
     val searcherType: SearcherType,
     val searchRequestHandler: SearchRequestHandler,
-    val imageUrls: List<String>? = null,
-    val menuIds: List<Long>? = null,
+//    val imageUrls: List<String>? = null,
+//    val menuIds: List<Long>? = null,
+        var searched: List<Any>? = null
 )

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearcherService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearcherService.kt
@@ -43,7 +43,7 @@ class SearcherService(
 
         return coroutineScope {
             searchContext.postProcessors.forEach {
-                response.results.map { result -> result.searched = it.process(response) }
+                it.process(response)
             }
         }
     }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearcherService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearcherService.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class SearcherService(
-    private val searcherGateway: SearcherGateway,
+        private val searcherGateway: SearcherGateway,
 ) {
 
     suspend fun search(searchContext: SearchContext): SearchResponse {
@@ -30,20 +30,20 @@ class SearcherService(
     private suspend fun query(searchContext: SearchContext): SearchResponse {
         return coroutineScope {
             val results = searchContext.searchQueries
-                .map {
-                    async { searcherGateway.search(it.getSearcher(), it.buildRequest(searchContext)).awaitSingle() }
-                }.map{ it.await() }
-                .filter { it.statusCode == StatusCode.SUCCESS }
+                    .map {
+                        async { searcherGateway.search(it.getSearcher(), it.buildRequest(searchContext)).awaitSingle() }
+                    }.map { it.await() }
+                    .filter { it.statusCode == StatusCode.SUCCESS }
             SearchResponse(results)
         }
     }
 
     private suspend fun postProcessAfterSearch(
-        searchContext: SearchContext, response: SearchResponse) {
+            searchContext: SearchContext, response: SearchResponse) {
 
         return coroutineScope {
             searchContext.postProcessors.forEach {
-                it.process(response)
+                response.results.map { result -> result.searched = it.process(response) }
             }
         }
     }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/query/MenuCategoryRecommendationSearchQuery.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/query/MenuCategoryRecommendationSearchQuery.kt
@@ -1,0 +1,26 @@
+package org.heeheepresso.gateway.search.query
+
+import org.heeheepresso.gateway.search.SearchContext
+import org.heeheepresso.gateway.search.request.SearchRequest
+import org.heeheepresso.gateway.search.request.SearchRequestHandler
+import org.heeheepresso.gateway.search.searcher.SearcherType
+import org.springframework.stereotype.Service
+
+@Service
+class MenuCategoryRecommendationSearchQuery : SearchQuery {
+
+    companion object {
+        private const val CAROUSEL_PAGE_SIZE = 9
+    }
+
+    override fun getSearcher(): SearcherType {
+        return SearcherType.RECOMMENDATION
+    }
+
+    override fun buildRequest(searchContext: SearchContext): SearchRequest {
+        return SearchRequest(searchContext.getUserInfo().userId,
+                SearchRequestHandler.MENU_CATEGORY,
+                pageSize = CAROUSEL_PAGE_SIZE,
+                category = searchContext.category)
+    }
+}

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/request/SearchRequest.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/request/SearchRequest.kt
@@ -12,4 +12,8 @@ data class SearchRequest(
 ) {
     constructor(userId: Long, handler: SearchRequestHandler, pageSize: Int):
         this(userId = userId, handler = handler, storeId = 0, pageSize = pageSize, offset = 0, category = null)
+
+    constructor(userId: Long, handler: SearchRequestHandler, pageSize: Int, category: MenuCategory?):
+            this(userId = userId, handler = handler, storeId = 0, pageSize = pageSize, offset = 0, category = category)
+
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/request/SearchRequestHandler.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/request/SearchRequestHandler.kt
@@ -2,5 +2,6 @@ package org.heeheepresso.gateway.search.request
 
 enum class SearchRequestHandler {
     HOME,
+    MENU_CATEGORY,
     UNKNOWN,
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/searcher/EventSearcher.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/searcher/EventSearcher.kt
@@ -17,7 +17,7 @@ class EventSearcher: Searcher {
                 statusCode = StatusCode.SUCCESS,
                 searcherType = SearcherType.EVENT,
                 searchRequestHandler = SearchRequestHandler.HOME,
-                imageUrls = ImmutableList.of(
+                searched = ImmutableList.of(
                     "https://github.com/HeeHeePresso/Backend/assets/49651099/7febfe0c-4aa9-47c1-8e74-cac555327349",
                     "https://github.com/HeeHeePresso/Backend/assets/49651099/7febfe0c-4aa9-47c1-8e74-cac555327349",
                     "https://github.com/HeeHeePresso/Backend/assets/49651099/7febfe0c-4aa9-47c1-8e74-cac555327349")

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/searcher/RecommendationSearcher.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/searcher/RecommendationSearcher.kt
@@ -23,7 +23,7 @@ class RecommendationSearcher(
                     statusCode = if(it.success) SUCCESS else SERVER_ERROR,
                     searcherType = SearcherType.RECOMMENDATION,
                     searchRequestHandler = request.handler,
-                    menuIds = it.data.recommendedMenus.map{ menu -> menu.menuId}
+                    searched = it.data.recommendedMenus.map{ menu -> menu.menuId}
             ) }
     }
 


### PR DESCRIPTION
## 변경사항
- 코드 구조 일부를 크게 수정한 감이 있어서 구분이나 롤백 편하게 하려고 바뀐 부분은 지우지 않고 주석 처리했습니다. 승인되면 주석을 제거하고 머지하겠습니다.
### 1. SearchContext에 카테고리로 조회 하기 위해 카테고리 필드 추가

### 2. 기존 Home 서비스에서 '메뉴 목록' 결과 가져오는 코드에 대한 의견
- SearchResponse에 굳이 Map타입의 extra 필드를 두고 PostProcessor를 통해 후처리하는 것이 필요할까 의문. (기존 HomeService 코드의 getMenuResult 메소드에서 이중으로 메뉴 ID 또는 MenuDetail Map으로 필터링하는게 좋지 않다고 봤음)
- 그래서 후처리의 정의를 어떻게 세울까 고민.
  - 기존 MenuDetailPostProcessor와 유사하게 검색 결과를 바탕으로 상세 메뉴를 조회함
  - 이와 마찬가지로 메뉴 뿐만 아니라 다른 서비스에서도 적용이 가능하게끔 SearchResponse에 공통 결과 필드인 searched를 정의하고 모든 타입이 수용 가능하게끔 Any 제네릭을 사용
  - 그런다음 후처리가 필요한 서비스에는 추가적인 결과를 도출하는 로직을 작성하게 만들고 결과 자체도 동일하게 Any 제네릭으로 하고, 기존 searched 필드에 overwrite하게 했다. (var 타입으로 선언)

### 3. SearcherService로 부터 받아온 결과(SearchResponse) 처리
- 기존에는 SearchResponse의 서비스 별 Result마다 '검색 타입', '검색 요청 핸들러'로 필터링으로 하고 조회하는 것을 봤다. 이것조차도 통일할 수 있을 것 같았다.
- SearchResponse 클래스에 "getResultBy" 메소드를 정의하고 파라미터로 '검색 타입', '검색 요청 핸들러'를 받고 조회하게끔했고, 실제 결과는 Any타입으로 지정되어있었기 때문에 타입 구체화된 결과를 얻기 위해 메소드에 제네릭을 붙여주었다. 
  - 하지만 이는 런타임 중에 판단되기 때문에 `reified` 키워드를 붙여주었고, 이 키워드를 쓰려면 inline 함수여야되기 때문에 함수 signature가  그렇게 정의되었다. (좋은 방법인지는 모르겠다.)
- 그래서 두개의 파라미터로 검색한 결과의 실제 조회된 결과의 타입이 제네릭타입이고, null도 아니면 **구체화된 타입 결과**를 반환하게끔 했고 아니면 빈 리스트를 반환하기로 함.