### PR TITLE
[GW] feat: 카테고리 별 메뉴 목록 조회 API 구현

### DIFF
--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/common/extension/StringExtension.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/common/extension/StringExtension.kt
@@ -1,8 +1,8 @@
 package org.heeheepresso.gateway.common.extension
 
 import org.heeheepresso.gateway.menu.category.MenuCategory
-import org.heeheepresso.gateway.search.request.SearchRequestHandler
 import org.heeheepresso.gateway.search.request.SearchRequestHandler.HOME
+import org.heeheepresso.gateway.search.request.SearchRequestHandler.MENU_CATEGORY
 
 class StringExtension {
 
@@ -13,8 +13,10 @@ internal fun String.getMenuCategory(): MenuCategory {
 }
 
 internal fun String.convertRecommendedUrl(): String {
-    return when(this) {
+    return when (this) {
         HOME.name -> "/home/recommend"
+//        MENU_CAGORY.name -> "/menu/category/recommend"
+        MENU_CATEGORY.name -> "/home/recommend"
         else -> ""
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/CategoryMenusResponse.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/CategoryMenusResponse.kt
@@ -1,0 +1,8 @@
+package org.heeheepresso.gateway.menu.category
+
+import org.heeheepresso.gateway.home.MenuResult
+
+data class CategoryMenusResponse(
+        val menuCategory: MenuCategory,
+        val menuInfos: List<MenuResult>
+)

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/controller/MenuCategoryController.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/controller/MenuCategoryController.kt
@@ -1,0 +1,19 @@
+package org.heeheepresso.gateway.menu.category.controller
+
+import org.heeheepresso.gateway.common.response.GatewayResponse
+import org.heeheepresso.gateway.menu.category.CategoryMenusResponse
+import org.heeheepresso.gateway.menu.category.MenuCategory
+import org.heeheepresso.gateway.menu.category.service.MenuCategoryService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MenuCategoryController(
+        private val menuCategoryService: MenuCategoryService
+) {
+    @GetMapping("/menus")
+    suspend fun getMenusByCategory(@RequestParam("category") menuCategory: MenuCategory, @RequestParam("userId") userId: Long): GatewayResponse<CategoryMenusResponse> {
+        return GatewayResponse(menuCategoryService.getMenusByCategory(menuCategory, userId))
+    }
+}

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/service/MenuCategoryService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/service/MenuCategoryService.kt
@@ -9,8 +9,8 @@ import org.heeheepresso.gateway.menu.domain.MenuBase
 import org.heeheepresso.gateway.processor.post.MenuDetailSearchProcessor
 import org.heeheepresso.gateway.search.*
 import org.heeheepresso.gateway.search.query.MenuCategoryRecommendationSearchQuery
-import org.heeheepresso.gateway.search.request.SearchRequestHandler
-import org.heeheepresso.gateway.search.searcher.SearcherType
+import org.heeheepresso.gateway.search.request.SearchRequestHandler.*
+import org.heeheepresso.gateway.search.searcher.SearcherType.*
 import org.springframework.stereotype.Service
 
 @Service
@@ -30,7 +30,7 @@ class MenuCategoryService(
     private fun buildSearchContext(userId: Long, category: MenuCategory): SearchContext {
         return SearchContext(
                 UserInfo(userId = userId),
-                searchRequestType = SearchRequestType.HOME,
+                searchRequestType = SearchRequestType.MENU_CATEGORY,
                 contextElaborators = ImmutableList.of(userInfoContextElaborator),
                 searchQueries = ImmutableList.of(menuCategoryRecommendationSearchQuery),
                 postProcessors = ImmutableList.of(menuDetailSearchProcessor),
@@ -43,7 +43,7 @@ class MenuCategoryService(
     }
 
     private fun getMenuResult(response: SearchResponse): List<MenuResult> {
-        val menuBases = response.getResultBy<MenuBase>(searcherType = SearcherType.RECOMMENDATION, searchRequestHandler = SearchRequestHandler.MENU_CATEGORY)
-        return ImmutableList.of(MenuResult(SearchRequestHandler.HOME.name, menuBases))
+        val menuBases = response.getResultBy<MenuBase>(searcherType = RECOMMENDATION, searchRequestHandler = MENU_CATEGORY)
+        return ImmutableList.of(MenuResult(MENU_CATEGORY.name, menuBases))
     }
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/service/MenuCategoryService.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/menu/category/service/MenuCategoryService.kt
@@ -1,0 +1,49 @@
+package org.heeheepresso.gateway.menu.category.service
+
+import com.google.common.collect.ImmutableList
+import org.heeheepresso.gateway.context.UserInfoContextElaborator
+import org.heeheepresso.gateway.home.MenuResult
+import org.heeheepresso.gateway.menu.category.CategoryMenusResponse
+import org.heeheepresso.gateway.menu.category.MenuCategory
+import org.heeheepresso.gateway.menu.domain.MenuBase
+import org.heeheepresso.gateway.processor.post.MenuDetailSearchProcessor
+import org.heeheepresso.gateway.search.*
+import org.heeheepresso.gateway.search.query.MenuCategoryRecommendationSearchQuery
+import org.heeheepresso.gateway.search.request.SearchRequestHandler
+import org.heeheepresso.gateway.search.searcher.SearcherType
+import org.springframework.stereotype.Service
+
+@Service
+class MenuCategoryService(
+        private val searcherService: SearcherService,
+        private val userInfoContextElaborator: UserInfoContextElaborator,
+        private val menuDetailSearchProcessor: MenuDetailSearchProcessor,
+        private val menuCategoryRecommendationSearchQuery: MenuCategoryRecommendationSearchQuery
+) {
+
+    suspend fun getMenusByCategory(menuCategory: MenuCategory, userId: Long): CategoryMenusResponse {
+        val response = searcherService.search(buildSearchContext(userId, menuCategory))
+
+        return buildResponse(category = menuCategory, response = response)
+    }
+
+    private fun buildSearchContext(userId: Long, category: MenuCategory): SearchContext {
+        return SearchContext(
+                UserInfo(userId = userId),
+                searchRequestType = SearchRequestType.HOME,
+                contextElaborators = ImmutableList.of(userInfoContextElaborator),
+                searchQueries = ImmutableList.of(menuCategoryRecommendationSearchQuery),
+                postProcessors = ImmutableList.of(menuDetailSearchProcessor),
+                category = category
+        )
+    }
+
+    private fun buildResponse(category: MenuCategory, response: SearchResponse): CategoryMenusResponse {
+        return CategoryMenusResponse(category, getMenuResult(response))
+    }
+
+    private fun getMenuResult(response: SearchResponse): List<MenuResult> {
+        val menuBases = response.getResultBy<MenuBase>(searcherType = SearcherType.RECOMMENDATION, searchRequestHandler = SearchRequestHandler.MENU_CATEGORY)
+        return ImmutableList.of(MenuResult(SearchRequestHandler.HOME.name, menuBases))
+    }
+}

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearchRequestType.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/SearchRequestType.kt
@@ -2,4 +2,5 @@ package org.heeheepresso.gateway.search
 
 enum class SearchRequestType {
     HOME,
+    MENU_CATEGORY
 }

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/query/MenuCategoryRecommendationSearchQuery.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/query/MenuCategoryRecommendationSearchQuery.kt
@@ -1,0 +1,26 @@
+package org.heeheepresso.gateway.search.query
+
+import org.heeheepresso.gateway.search.SearchContext
+import org.heeheepresso.gateway.search.request.SearchRequest
+import org.heeheepresso.gateway.search.request.SearchRequestHandler
+import org.heeheepresso.gateway.search.searcher.SearcherType
+import org.springframework.stereotype.Service
+
+@Service
+class MenuCategoryRecommendationSearchQuery : SearchQuery {
+
+    companion object {
+        private const val CAROUSEL_PAGE_SIZE = 9
+    }
+
+    override fun getSearcher(): SearcherType {
+        return SearcherType.RECOMMENDATION
+    }
+
+    override fun buildRequest(searchContext: SearchContext): SearchRequest {
+        return SearchRequest(userId = searchContext.getUserInfo().userId,
+                handler = SearchRequestHandler.MENU_CATEGORY,
+                pageSize = CAROUSEL_PAGE_SIZE,
+                category = searchContext.category)
+    }
+}

--- a/gateway/src/main/kotlin/org/heeheepresso/gateway/search/request/SearchRequestHandler.kt
+++ b/gateway/src/main/kotlin/org/heeheepresso/gateway/search/request/SearchRequestHandler.kt
@@ -2,5 +2,6 @@ package org.heeheepresso.gateway.search.request
 
 enum class SearchRequestHandler {
     HOME,
+    MENU_CATEGORY,
     UNKNOWN,
 }


### PR DESCRIPTION
(리팩토링 코드 실수로 메인에다가 다이렉트 푸시해버렸어요 ㅠㅠ)
## 변경사항
- 검색 요청 핸들러 항목 추가: MENU_CATEGORY
- 메뉴 카테고리 조회를 위한 SearchQuery 정의
- 추천 서비스에서 '카테고리 별 메뉴 추천 목록' 조회를 위한 String Extension URI 추가
- 카테고리 메뉴 응답 dto 정의 (피그마 상의 "추천" 카테고리 항목도 커버 가능하게끔)
- 메뉴 카테고리 서비스 및 컨트롤러 정의
  - elaborator: UserInfo
  - searchQuery: MenuCategory
  - postProcessor: MenuDetail